### PR TITLE
easynav: 0.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1827,7 +1827,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/EasyNavigation/EasyNavigation-release.git
-      version: 0.3.2-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/EasyNavigation/EasyNavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav` to `0.4.1-1`:

- upstream repository: https://github.com/EasyNavigation/EasyNavigation.git
- release repository: https://github.com/EasyNavigation/EasyNavigation-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.2-1`

## easynav

```
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico
```

## easynav_common

```
* Added get_no_group in NavState
* get_by_type and get_to_vector in NavState
* Add default group. Add debug info
* Fix bug in NavState when updating an existing key via pointer
* Refactor PerceptionHandler
  PerceptionHandler now represents a single sensor input, not a sensor group
* Perception types and ops to easynav_sensors
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Add the option to get the fuse() efective timestamp
* Improve navstate print including the time
* Add exact_time parameter to fuse to use the last TF if false
* Adjust process time to input times
* Fix TF stucks
* Get last ime of the perceptions in a view
  Add a base_footprint frame in TFInfo
* Update tests
* Set robot_frame as default for the perception pipeline
* Add a bas_footprint frame in TFInfo
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_controller

```
* Merge rolling (coverage changes) into refactor_perception
  Increase coverage
* fix(tests): fix node destructors and add comprehensive tests for controller/planner/localizer/maps_manager
  - Fix != to == in lifecycle transition guards in all 4 node destructors
  - Fix MapsManagerNode destructor: declare_parameter -> get_parameter with has_parameter guard
  - Fix unloadLibraryForClass to use actual plugin class name (from .plugin param) not sensor name
  - Null method/manager pointers before calling unload to avoid ClassLoader SIGSEGV
  - Expand inline catch blocks to satisfy uncrustify style
  - Add 11 tests for ControllerNode, 11 for PlannerNode, 12 for LocalizerNode, 10 for MapsManagerNode
  - All tests cover: node name, lifecycle transitions, plugin loading success/failure, cycle methods
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
  Add a base_footprint frame in TFInfo
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_core

```
* get_by_type and get_to_vector in NavState
* Merge rolling (coverage changes) into refactor_perception
* Refactor PerceptionHandler
  PerceptionHandler now represents a single sensor input, not a sensor group
  Increase coverage
* Fix test bug in plugin class loader
* Perception types and ops to easynav_sensors
* GPLv3 -> Apache 2.0
* Adjust process time to input times
* Sync time for markers with its the collision percetion time
* Set robot_frame as default for collision checker
* Add a base_footprint frame in TFInfo
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_interfaces

```
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico
```

## easynav_localizer

```
* Register Odometry printer in base LocalizerNode
* Remove nav_state write from dummy localizer
* Merge rolling (coverage changes) into refactor_perception
* fix(tests): fix node destructors and add comprehensive tests for controller/planner/localizer/maps_manager
  - Fix != to == in lifecycle transition guards in all 4 node destructors
  - Fix MapsManagerNode destructor: declare_parameter -> get_parameter with has_parameter guard
  - Fix unloadLibraryForClass to use actual plugin class name (from .plugin param) not sensor name
  - Null method/manager pointers before calling unload to avoid ClassLoader SIGSEGV
  - Expand inline catch blocks to satisfy uncrustify style
  - Add 11 tests for ControllerNode, 11 for PlannerNode, 12 for LocalizerNode, 10 for MapsManagerNode
  - All tests cover: node name, lifecycle transitions, plugin loading success/failure, cycle methods
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_maps_manager

```
* Merge rolling (coverage changes) into refactor_perception
* Fix test bug in plugin class loader
* fix(tests): fix node destructors and add comprehensive tests for controller/planner/localizer/maps_manager
  - Fix != to == in lifecycle transition guards in all 4 node destructors
  - Fix MapsManagerNode destructor: declare_parameter -> get_parameter with has_parameter guard
  - Fix unloadLibraryForClass to use actual plugin class name (from .plugin param) not sensor name
  - Null method/manager pointers before calling unload to avoid ClassLoader SIGSEGV
  - Expand inline catch blocks to satisfy uncrustify style
  - Add 11 tests for ControllerNode, 11 for PlannerNode, 12 for LocalizerNode, 10 for MapsManagerNode
  - All tests cover: node name, lifecycle transitions, plugin loading success/failure, cycle methods
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_planner

```
* Merge rolling (coverage changes) into refactor_perception
* fix(tests): fix node destructors and add comprehensive tests for controller/planner/localizer/maps_manager
  - Fix != to == in lifecycle transition guards in all 4 node destructors
  - Fix MapsManagerNode destructor: declare_parameter -> get_parameter with has_parameter guard
  - Fix unloadLibraryForClass to use actual plugin class name (from .plugin param) not sensor name
  - Null method/manager pointers before calling unload to avoid ClassLoader SIGSEGV
  - Expand inline catch blocks to satisfy uncrustify style
  - Add 11 tests for ControllerNode, 11 for PlannerNode, 12 for LocalizerNode, 10 for MapsManagerNode
  - All tests cover: node name, lifecycle transitions, plugin loading success/failure, cycle methods
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_sensors

```
* Merge remote-tracking branch 'origin/rolling' into rolling
* Prevent possible race condition in PointPerceptions
* Fix out-of-bounds error in SensorsNode
* Add Odometry perception handler to sensors
* Fix bug when using multiple sensors
* Updating tests
* Added get_no_group in NavState
* get_by_type and get_to_vector in NavState
* Add default group. Add debug info
* PerceptionHandler: Store parent node as weak_ptr
* Merge rolling (coverage changes) into refactor_perception
* Refactor PerceptionHandler
  PerceptionHandler now represents a single sensor input, not a sensor group
* Increase coverage
* Configure failure propagation
* Mantain Perception Handler per sensor
* Add sensors' PerceptionHandler as plugins
* Merge branch 'rolling' into refactor_perception
* Perception types and ops to easynav_sensors
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Update tests
* Add a base_footprint frame in TFInfo
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, jagutic
```

## easynav_support_py

```
* Merge remote-tracking branch 'origin/rolling' into rolling
* Try fix Python tests
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, jagutic
```

## easynav_system

```
* Limit GoalManager publication freq
* New parameters for system node -> freq and rt_freq
* Perception types and ops to easynav_sensors
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Add a base_footprint frame in TFInfo
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, jagutic
```

## easynav_tools

```
* Try fix Python tests
* Add default group. Add debug info
* Merge rolling (coverage changes) into refactor_perception
* Increase coverage
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, jagutic
```
