### PR TITLE
easynav_plugins: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2603,6 +2603,7 @@ repositories:
       - easynav_navmap_maps_manager
       - easynav_navmap_planner
       - easynav_octomap_maps_manager
+      - easynav_regulated_pp_controller
       - easynav_routes_maps_manager
       - easynav_serest_controller
       - easynav_simple_common
@@ -2614,7 +2615,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/EasyNavigation/easynav_plugins-release.git
-      version: 0.2.1-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/EasyNavigation/easynav_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav_plugins` to `0.4.0-1`:

- upstream repository: https://github.com/EasyNavigation/easynav_plugins.git
- release repository: https://github.com/EasyNavigation/easynav_plugins-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.1-2`

## easynav_bonxai_maps_manager

```
* Add missing easynav_sensors deps
* Update calls to deprecated get_package_share_directory
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_costmap_common

```
* Add missing easynav_sensors deps
* Any change in the costmap set it as modified
* Adding timestamp to costmap
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely G., Miguel, migueldm
```

## easynav_costmap_localizer

```
* Add missing easynav_sensors deps
* Avoid creating objects every loop cycle
* Fix std::normal_distribution when stdev is zero
* Check if std is non-positive before creating std::normal_distribution
  Dynamic base costmap
* Change map static to base
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Merge branch 'EasyNavigation:rolling' into rolling
* GPLv3 -> Apache 2.0
* Sync to current EasyNavigation
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_costmap_maps_manager

```
* Add missing easynav_sensors deps
* Update dynamic_map_ with map key at navstate
* Avoid rewrite map with dynamic_map
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Update calls to deprecated get_package_share_directory
* Update dynamic_map_ with map key at navstate
* Navstate key among filters are always map, not an arbitrary key
* Any change in the costmap set it as modified
* Publish changes in base map and be ready to save updated map
* Costamp base map sincronized with nav_state
* Change map static to base
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_costmap_planner

```
* Sync with Rolling branch
* Cells cost have no real impact in path creation
* Navstate key among filters are always map, not an arbitrary key
* Cells cost have no real impact in path creation
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely G., Miguel, migueldm
```

## easynav_fusion_localizer

```
* Add missing easynav_sensors deps
* deleted tests related to initial pose param which was removed. Removed spaces
* fix: add gnss group to gps config and ge_group has group to meet new easynav features. Initial pose now changes initial utm pose to change robot position in the map
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
  New version of fusion localizer tested in real robot and simulator
* Added config file for gazebo simulation demo
* Only starts filter if params are found
* params updated
* Added simple configuration to launch full demo
* Initialization considers IMU orientation
* Merge branch 'rolling' of github.com:midemig/easynav_plugins into rolling
* Call set pose srvc for first pose for fastest convergence. Updated params to stabilice the filter in summit
* GPLv3 -> Apache 2.0
* fixed odom topic
* Several bugs fixed. Now it correctly integrates GPS measurements to the dual filter.
* Added dual ukf for local and global localization
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, midemig, migueldm
```

## easynav_gps_localizer

```
* Add missing easynav_sensors deps
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely G., Miguel, migueldm
```

## easynav_mpc_controller

```
* Add missing easynav_sensors deps
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
* Add missing easynav_sensors deps
* Add missing easynav_sensors deps
* Sync with Rolling branch
* Sync with rolling branch
* Merge pull request #61 <https://github.com/EasyNavigation/easynav_plugins/issues/61> from Butakus/rolling
  Update plugins to new sensors API
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* 0.3.1
* update changelogs
* Merge branch 'rolling' of github.com:midemig/easynav_plugins into rolling
* Merge branch 'EasyNavigation:rolling' into rolling
* Merge pull request #51 <https://github.com/EasyNavigation/easynav_plugins/issues/51> from EasyNavigation/license-kilted
  GPLv3 -> Apache 2.0
* GPLv3 -> Apache 2.0
* Merge pull request #50 <https://github.com/EasyNavigation/easynav_plugins/issues/50> from EasyNavigation/license
  GPLv3 -> Apache 2.0
* Merge pull request #49 <https://github.com/EasyNavigation/easynav_plugins/issues/49> from juanscelyg/rolling
  Latest Updates and Corrected CI
* Merge pull request #48 <https://github.com/EasyNavigation/easynav_plugins/issues/48> from juanscelyg/kilted
  Kilted
* GPLv3 -> Apache 2.0
* Latest changes were added
* Dependencies were corrected
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_mppi_controller

```
* Add missing easynav_sensors deps
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_navmap_localizer

```
* Add missing easynav_sensors deps
* Check if std is non-positive before creating std::normal_distribution
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_navmap_maps_manager

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_navmap_planner

```
* Sync with Rolling branch
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely G., Miguel, migueldm
```

## easynav_octomap_maps_manager

```
* Add missing easynav_sensors deps
* Update calls to deprecated get_package_share_directory
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_regulated_pp_controller

```
* Add missing easynav_sensors deps
* Fix overshoot when DWPP is activated
* Fix license and copyright
* Port of Regulated Pure Pursuit. Initial commit
* Contributors: Francisco Martín Rico
```

## easynav_routes_maps_manager

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Merge pull request #57 <https://github.com/EasyNavigation/easynav_plugins/issues/57> from midemig/savemap_default
  Added default path for route if not specified
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_serest_controller

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Sync to current EasyNavigation
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_common

```
* Sync with Rolling branch
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_controller

```
* Add missing easynav_sensors deps
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_localizer

```
* Add missing easynav_sensors deps
* Avoid creating objects every loop cycle
* Fix std::normal_distribution when stdev is zero
* Navstate key among filters are always map, not an arbitrary key
* Check if std is non-positive before creating std::normal_distribution
* Navstate key among filters are always map, not an arbitrary key
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_maps_manager

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Reset pose from RViz2 for every localizer
* Remove group points in tests
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_planner

```
* Sync with Rolling branch
* Navstate key among filters are always map, not an arbitrary key
* Navstate key among filters are always map, not an arbitrary key
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely G., Miguel, migueldm
```

## easynav_vff_controller

```
* Add missing easynav_sensors deps
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Sync to current EasyNavigation
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely G., Miguel, migueldm
```
