### PR TITLE
easynav_plugins: 0.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1853,6 +1853,7 @@ repositories:
       - easynav_navmap_maps_manager
       - easynav_navmap_planner
       - easynav_octomap_maps_manager
+      - easynav_regulated_pp_controller
       - easynav_routes_maps_manager
       - easynav_serest_controller
       - easynav_simple_common
@@ -1864,7 +1865,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/EasyNavigation/easynav_plugins-release.git
-      version: 0.3.1-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/EasyNavigation/easynav_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav_plugins` to `0.4.1-1`:

- upstream repository: https://github.com/EasyNavigation/easynav_plugins.git
- release repository: https://github.com/EasyNavigation/easynav_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.1-1`

## easynav_bonxai_maps_manager

```
* Add missing easynav_sensors deps
* Update calls to deprecated get_package_share_directory
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_costmap_common

```
* Add missing easynav_sensors deps
* Any change in the costmap set it as modified
* Adding timestamp to costmap
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely, Miguel, migueldm
```

## easynav_costmap_localizer

```
* Add missing easynav_sensors deps
* Avoid creating objects every loop cycle
* Fix std::normal_distribution when stdev is zero
* Check if std is non-positive before creating std::normal_distribution
  Dynamic base costmap
* Change map static to base
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_costmap_maps_manager

```
* Add missing easynav_sensors deps
* Update dynamic_map_ with map key at navstate
* Avoid rewrite map with dynamic_map
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Update calls to deprecated get_package_share_directory
* Update dynamic_map_ with map key at navstate
* Avoid rewrite map with dynamic_map
* Navstate key among filters are always map, not an arbitrary key
  Dynamic base costmap
* Any change in the costmap set it as modified
* Publish changes in base map and be ready to save updated map
* Costamp base map sincronized with nav_state
* Change map static to base
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_costmap_planner

```
* Sync with rolling branch
* Navstate key among filters are always map, not an arbitrary key
* Cells cost have no real impact in path creation
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely, Miguel, migueldm
```

## easynav_fusion_localizer

```
* Add missing easynav_sensors deps
* deleted tests related to initial pose param which was removed. Removed spaces
* fix: add gnss group to gps config and ge_group has group to meet new easynav features. Initial pose now changes initial utm pose to change robot position in the map
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Added config file for gazebo smulation demo
* Only starts filter if params are found
* Added simple configuration to launch full demo
* Initialization considers IMU orientation
* Call set pose srvc for first pose for fastest convergence. Updated params to stabilice the filter in summit
* GPLv3 -> Apache 2.0
* fixed odom topic
* Several bugs fixed. Now it correctly integrates GPS measurements to the dual filter.
* Added dual ukf for local and global localization
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, midemig, migueldm
```

## easynav_gps_localizer

```
* Add missing easynav_sensors deps
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely, Miguel, migueldm
```

## easynav_mpc_controller

```
* Add missing easynav_sensors deps
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Collision checker scope was changed
* Collision avoidance was improved
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_mppi_controller

```
* Add missing easynav_sensors deps
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_navmap_localizer

```
* Add missing easynav_sensors deps
* Check if std is non-positive before creating std::normal_distribution
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_navmap_maps_manager

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_navmap_planner

```
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely, Miguel, migueldm
```

## easynav_octomap_maps_manager

```
* Add missing easynav_sensors deps
* Update calls to deprecated get_package_share_directory
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Dependencies were corrected
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_regulated_pp_controller

```
* Add missing easynav_sensors deps
* Fix overshoot when DWPP is activated
* Fix license and copyright
* Fix license and copyright
* Port of Regulated Pure Pursuit. Initial commit
* Contributors: Francisco Martín Rico
```

## easynav_routes_maps_manager

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Added default path for route if not specified
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_serest_controller

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_simple_common

```
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely, Miguel, migueldm
```

## easynav_simple_controller

```
* Add missing easynav_sensors deps
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely, Miguel, migueldm
```

## easynav_simple_localizer

```
* Add missing easynav_sensors deps
* Avoid creating objects every loop cycle
* Fix std::normal_distribution when stdev is zero
* Navstate key among filters are always map, not an arbitrary key
* Check if std is non-positive before creating std::normal_distribution
* Check if std is non-positive before creating std::normal_distribution
* Navstate key among filters are always map, not an arbitrary key
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_simple_maps_manager

```
* Add missing easynav_sensors deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Reset pose from RViz2 for every localizer
* Remove group points in tests
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_simple_planner

```
* Navstate key among filters are always map, not an arbitrary key
* Navstate key among filters are always map, not an arbitrary key
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Juan S. Cely, Miguel, migueldm
```

## easynav_vff_controller

```
* Add missing easynav_sensors deps
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```
