### PR TITLE
easynav_plugins: 0.4.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1861,6 +1861,44 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
       version: ros2
     status: maintained
+  easynav_plugins:
+    doc:
+      type: git
+      url: https://github.com/EasyNavigation/easynav_plugins.git
+      version: lyrical
+    release:
+      packages:
+      - easynav_bonxai_maps_manager
+      - easynav_costmap_common
+      - easynav_costmap_localizer
+      - easynav_costmap_maps_manager
+      - easynav_costmap_planner
+      - easynav_fusion_localizer
+      - easynav_gps_localizer
+      - easynav_mpc_controller
+      - easynav_mppi_controller
+      - easynav_navmap_localizer
+      - easynav_navmap_maps_manager
+      - easynav_navmap_planner
+      - easynav_octomap_maps_manager
+      - easynav_regulated_pp_controller
+      - easynav_routes_maps_manager
+      - easynav_serest_controller
+      - easynav_simple_common
+      - easynav_simple_controller
+      - easynav_simple_localizer
+      - easynav_simple_maps_manager
+      - easynav_simple_planner
+      - easynav_vff_controller
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/EasyNavigation/easynav_plugins-release.git
+      version: 0.4.2-1
+    source:
+      type: git
+      url: https://github.com/EasyNavigation/easynav_plugins.git
+      version: lyrical
+    status: developed
   ecal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav_plugins` to `0.4.2-1`:

- upstream repository: https://github.com/EasyNavigation/easynav_plugins.git
- release repository: https://github.com/EasyNavigation/easynav_plugins-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## easynav_bonxai_maps_manager

```
* Complete deps
* Update calls to deprecated get_package_share_directory
* GPLv3 -> Apache 2.0
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Cleanup unused headers
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_costmap_common

```
* Complete deps
* Any change in the costmap set it as modified
* Adding timestamp to costmap
* GPLv3 -> Apache 2.0
* Remove C++20/C++23 features and update to new MethodBase interface
* Cleanup unused headers
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_costmap_localizer

```
* Complete deps
* Avoid creating objects every loop cycle
* Fix std::normal_distribution when stdev is zero
* Check if std is non-positive before creating std::normal_distribution
* Check if std is non-positive before creating std::normal_distribution
* Change map static to base
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Correct publication stamp to input stamp
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
  Optimize execution
* Optimize random genearator
* Optimize execution
* Cleanup unused headers
* Adaptation to EasyNavigation`#71 <https://github.com/EasyNavigation/easynav_plugins/issues/71>`_
* Init pose for RViz2 compliant
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_costmap_maps_manager

```
* Complete deps
* Update dynamic_map_ with map key at navstate
* Avoid rewrite map with dynamic_map
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Update dynamic_map_ with map key at navstate
* Avoid rewrite map with dynamic_map
* Navstate key among filters are always map, not an arbitrary key
* Merge fix
* Any change in the costmap set it as modified
* Publish changes in base map and be ready to save updated map
* Costamp base map sincronized with nav_state
* Change map static to base
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Get timestamp from perception for stamping
* Improve navstate print including the time
* Use last available TF for obstacle filter
* Adjust output time in costamp stack
* Remove C++20/C++23 features and update to new MethodBase interface
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* linting docs
* fix: Prevent A* planner from traversing through obstacles
* Final optimization
* First UpdateCosts optimization
* Update perception bound
* Cleanup unused headers
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Jose Miguel, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_costmap_planner

```
* Complete deps
* Navstate key among filters are always map, not an arbitrary key
* Cells cost have no real impact in path creation
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Adjust output time in costamp stack
* Remove C++20/C++23 features and update to new MethodBase interface
* TFInfo in RTTFBuffer
* Improve heuristic
* Refactor to use TFInfo
* lintering
* Stop controllers at IDLE
* Publish more frequently
* Improve efficiency in A*
* fix: Prevent A* planner from traversing through obstacles
* Optimize execution
* Cleanup unused headers
* Merge branch 'EasyNavigation:rolling' into rolling
* Update sheets
* Update sheets
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Jose Miguel, José Miguel Guerrero, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_fusion_localizer

```
* Complete deps
* deleted tests related to initial pose param which was removed. Removed spaces
* fix: add gnss group to gps config and ge_group has group to meet new easynav features. Initial pose now changes initial utm pose to change robot position in the map
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Added config file for gazebo smulation demo
* Uncrustify changes
* Only starts filter if params are found
* params updated
* Added simple configuration to launch full demo
* Initialization considers IMU orientation
* Call set pose srvc for first pose for fastest convergence. Updated params to stabilice the filter in summit
* GPLv3 -> Apache 2.0
* fixed odom topic
* Several bugs fixed. Now it correctly integrates GPS measurements to the dual filter.
* Added dual ukf for local and global localization
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Fixed frames. In robot_localization, world frame must be odom or map depending on filter mode: local or global. This first version works as only global filter, so I changed world frame to map
* Refactor to use TFInfo
* fixed subscribers cb group, not in rt
* added pkg to workflow and ament_uncrustify code
* First working version
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, midemig, migueldm
```

## easynav_gps_localizer

```
* Complete deps
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* GPLv3 -> Apache 2.0
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* linting docs
* Cleanup unused headers
* Update sheets
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_mpc_controller

```
* Complete deps
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Collision checker scope was changed
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Collision avoidance was improved
* Final alignements
* Trim path for MPC
* Stop controllers at IDLE
* Obstacles are detected
* Methods were added to access to private attributes
* Optimizer header file was added
* Dependencies were fixed
* MPC with differential model is working
* MPC Controller minimizes path following
* Visualization Marker was added
* MPC was tunned
* MPC controller is working
* Optimizer was changed
* Dependecies were added
* MPC terminated
* MPC was added
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, José Miguel Guerrero, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_mppi_controller

```
* Complete deps
* GPLv3 -> Apache 2.0
* Remove C++20/C++23 features and update to new MethodBase interface
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Include package in cmake and package.xml
* Fix link error when running MPPI in Realease
* Stop controllers at IDLE
* Merge branch 'rolling' into improve_astar_costmap
* Referencing base class if ot void
* Optimize execution
* Cleanup unused headers
* Adaptation to EasyNavigation`#71 <https://github.com/EasyNavigation/easynav_plugins/issues/71>`_
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, José Miguel Guerrero, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_navmap_localizer

```
* Complete deps
* Check if std is non-positive before creating std::normal_distribution
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Correct publication stamp to input stamp
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Optimize execution
* Optimize random genearator
* Optimize execution
* Update sheets
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_navmap_maps_manager

```
* Complete deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Final adjustements
* Refactor to use TFInfo
* Merge branch 'rolling' into improve_astar_costmap
* linting docs
* Optimize execution
  Cleanup unused headers
* Dependencies were fixed
* Update sheets
* First functional version of Inflation filter
* Update to Occ constants
* Add obstacle layer
* Optimized function
* First functional verison, but expensive
* Update sheets
* First functional version of Inflation filter
* Update to Occ constants
* Add obstacle layer
* Optimized function
* First functional verison, but expensive
* Add params to navmap building map
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_navmap_planner

```
* Complete deps
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Optimize execution
* Cleanup unused headers
* Update sheets
* Path planner aware of obstacles and inflation
* A Star uses obstacle layer
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_octomap_maps_manager

```
* Complete deps
* Update calls to deprecated get_package_share_directory
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Remove C++20/C++23 features and update to new MethodBase interface
* TFInfo in RTTFBuffer
* Sync README with code
* Cleanup unused headers
* Adaptation to EasyNavigation`#71 <https://github.com/EasyNavigation/easynav_plugins/issues/71>`_
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_regulated_pp_controller

```
* Complete deps
* Fix overshoot when DWPP is activated
* Fix license and copyright
* Port of Regulated Pure Pursuit. Initial commit
* Contributors: Francisco Martín Rico
```

## easynav_routes_maps_manager

```
* Complete deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Added default path for route if not specified
* GPLv3 -> Apache 2.0
* Merge branch 'EasyNavigation:rolling' into rolling
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Final adjustements
* Refactor to use TFInfo
* Fix CMakeLists
* Added missing dep
* Added missing licenses
  Route server
* Tests and README
* Route Maps Manager with filters. Costmap filter
* Routes Maps manager finalized
* Add/Remove segment
* Interactive markers and ids in the segments
* Basic route server
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_serest_controller

```
* Complete deps
* Navstate key among filters are always map, not an arbitrary key
* Navstate key among filters are always map, not an arbitrary key
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Adjust output time in costmap stack
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Final alignements
* Referencing base class if ot void
* Fix Link error in controller
* Optimize execution
* Adaptation to EasyNavigation`#71 <https://github.com/EasyNavigation/easynav_plugins/issues/71>`_
* Fix CI with the correct branch
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, José Miguel Guerrero, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_common

```
* GPLv3 -> Apache 2.0
* TFInfo in RTTFBuffer
* Fix downsample in Simple
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Miguel, migueldm
```

## easynav_simple_controller

```
* Complete deps
* GPLv3 -> Apache 2.0
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Referencing base class if ot void
* Optimize execution
* Cleanup unused headers
* Merge branch 'EasyNavigation:rolling' into rolling
  Navmap obstacle layer
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_localizer

```
* Complete deps
* Avoid creating objects every loop cycle
* Fix std::normal_distribution when stdev is zero
* Navstate key among filters are always map, not an arbitrary key
* Check if std is non-positive before creating std::normal_distribution
* Check if std is non-positive before creating std::normal_distribution
* Navstate key among filters are always map, not an arbitrary key
* Update README.md for all localizers
* Reset pose from RViz2 for every localizer
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Correct publication stamp to input stamp
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Optimize execution
* Cleanup unused headers
* Update sheets
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_maps_manager

```
* Complete deps
* Navstate key among filters are always map, not an arbitrary key
* Update calls to deprecated get_package_share_directory
* Navstate key among filters are always map, not an arbitrary key
* Reset pose from RViz2 for every localizer
* Remove group points in tests
* Adaptations to #94 <https://github.com/EasyNavigation/easynav_plugins/issues/94>
* Update plugins to new sensors API
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* linting docs
* Sync README with code
* Cleanup unused headers
* Adaptation to EasyNavigation`#71 <https://github.com/EasyNavigation/easynav_plugins/issues/71>`_
* Update sheets
* Fix TF compilation warnings
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_simple_planner

```
* Complete deps
* Navstate key among filters are always map, not an arbitrary key
* Fix segfault in some cases and reduce extrapolation to the future
* GPLv3 -> Apache 2.0
* Improve navstate print including the time
* Remove C++20/C++23 features and update to new MethodBase interface
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```

## easynav_vff_controller

```
* Complete deps
* Update plugins to new sensors API
* Merge branch 'rolling' of github.com:midemig/easynav_plugins into rolling
* GPLv3 -> Apache 2.0
* Add a base_footprint frame in TFInfo
* Remove C++20/C++23 features and update to new MethodBase interface
* Merge branch 'set_robot_frame' into frames-fix-pr-40
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Referencing base class if ot void
* Optimize execution
* Cleanup unused headers
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, Juan S. Cely, Juan S. Cely G., Miguel, migueldm
```
