### PR TITLE
libbno055_linux: 1.7.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4071,7 +4071,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/lazytatzv/libbno055_linux-release.git
-      version: 1.7.1-1
+      version: 1.7.2-1
     source:
       type: git
       url: https://github.com/lazytatzv/libbno055-linux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libbno055_linux` to `1.7.2-1`:

- upstream repository: https://github.com/lazytatzv/libbno055-linux.git
- release repository: https://github.com/lazytatzv/libbno055_linux-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.1-1`
