### PR TITLE
fix euslisp/jskeus keys for ubuntu resolute

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1085,12 +1085,10 @@ ethtool:
   ubuntu: [ethtool]
 euslisp:
   debian: [euslisp]
-  ubuntu:
-    jammy: [euslisp]
+  ubuntu: [euslisp]
 euslisp-dev:
   debian: [euslisp-dev]
-  ubuntu:
-    jammy: [euslisp-dev]
+  ubuntu: [euslisp-dev]
 exfat-fuse:
   debian: [exfat-fuse]
   gentoo: [sys-fs/fuse-exfat]
@@ -2637,10 +2635,12 @@ jskeus:
   debian: [jskeus]
   ubuntu:
     jammy: [jskeus]
+    resolute: [jskeus]
 jskeus-dev:
   debian: [jskeus-dev]
   ubuntu:
     jammy: [jskeus-dev]
+    resolute: [jskeus-dev]
 julius-voxforge:
   fedora: [julius-voxforge]
   ubuntu: [julius-voxforge]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1085,10 +1085,14 @@ ethtool:
   ubuntu: [ethtool]
 euslisp:
   debian: [euslisp]
-  ubuntu: [euslisp]
+  ubuntu:
+    jammy: [euslisp]
+    resolute: [euslisp]
 euslisp-dev:
   debian: [euslisp-dev]
-  ubuntu: [euslisp-dev]
+  ubuntu:
+    jammy: [euslisp-dev]
+    resolute: [euslisp-dev]
 exfat-fuse:
   debian: [exfat-fuse]
   gentoo: [sys-fs/fuse-exfat]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1085,12 +1085,10 @@ ethtool:
   ubuntu: [ethtool]
 euslisp:
   debian: [euslisp]
-  ubuntu:
-    jammy: [euslisp]
+  ubuntu: [euslisp]
 euslisp-dev:
   debian: [euslisp-dev]
-  ubuntu:
-    jammy: [euslisp-dev]
+  ubuntu: [euslisp-dev]
 exfat-fuse:
   debian: [exfat-fuse]
   gentoo: [sys-fs/fuse-exfat]
@@ -2638,10 +2636,12 @@ jskeus:
   debian: [jskeus]
   ubuntu:
     jammy: [jskeus]
+    resolute: [jskeus]
 jskeus-dev:
   debian: [jskeus-dev]
   ubuntu:
     jammy: [jskeus-dev]
+    resolute: [jskeus-dev]
 julius-voxforge:
   fedora: [julius-voxforge]
   ubuntu: [julius-voxforge]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1085,14 +1085,10 @@ ethtool:
   ubuntu: [ethtool]
 euslisp:
   debian: [euslisp]
-  ubuntu:
-    jammy: [euslisp]
-    resolute: [euslisp]
+  ubuntu: [euslisp]
 euslisp-dev:
   debian: [euslisp-dev]
-  ubuntu:
-    jammy: [euslisp-dev]
-    resolute: [euslisp-dev]
+  ubuntu: [euslisp-dev]
 exfat-fuse:
   debian: [exfat-fuse]
   gentoo: [sys-fs/fuse-exfat]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please fix the following dependencies in the rosdep database.

## Package name:

euslisp, euslisp-dev, jskeus, jskeus-dev

## Package Upstream Source:

- https://github.com/euslisp/euslisp
- https://github.com/euslisp/jskeus

## Purpose of using this:

To release https://github.com/jsk-ros-pkg/jsk_roseus/pull/761

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=euslisp-dev
  - https://packages.debian.org/search?keywords=jskeus-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/euslisp-dev
  - https://packages.ubuntu.com/jskeus-dev
