### PR TITLE
proxsuite: 0.7.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8562,8 +8562,9 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/proxsuite-release.git
-      version: 0.6.5-1
+      version: 0.7.3-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/Simple-Robotics/proxsuite.git
       version: devel


### PR DESCRIPTION
Increasing version of package(s) in repository `proxsuite` to `0.7.3-1`:

- upstream repository: https://github.com/Simple-Robotics/proxsuite.git
- release repository: https://github.com/ros2-gbp/proxsuite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.5-1`
