### PR TITLE
elite_cs_series_sdk: 1.4.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2791,6 +2791,21 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  elite_cs_series_sdk:
+    doc:
+      type: git
+      url: https://github.com/EliteRobots/Elite_Robots_CS_SDK.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/EliteRobots/Elite_Robots_CS_SDK-release.git
+      version: 1.4.7-1
+    source:
+      type: git
+      url: https://github.com/EliteRobots/Elite_Robots_CS_SDK.git
+      version: main
+    status: maintained
   ess_imu_driver2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_cs_series_sdk` to `1.4.7-1`:

- upstream repository: https://github.com/EliteRobots/Elite_Robots_CS_SDK.git
- release repository: https://github.com/EliteRobots/Elite_Robots_CS_SDK-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
