### PR TITLE
toppra: 0.6.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10520,7 +10520,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/toppra-release.git
-      version: 0.6.8-1
+      version: 0.6.9-1
     source:
       type: git
       url: https://github.com/hungpham2511/toppra.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toppra` to `0.6.9-1`:

- upstream repository: https://github.com/hungpham2511/toppra.git
- release repository: https://github.com/ros2-gbp/toppra-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.8-1`

## toppra

```
* [cpp] Add exports to fix Windows builds (#294 <https://github.com/hungpham2511/toppra/issues/294>)
* [cpp] Simplify vector typedefs by removing allocators and drop support for Eigen 3.3 and lower (#290 <https://github.com/hungpham2511/toppra/issues/290>)
* Contributors: Sebastian Castro
```
