### PR TITLE
mrpt_ros: 2.15.20-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6598,7 +6598,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.19-1
+      version: 2.15.20-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.20-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.19-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

```
* mrpt_libbase: stop vendoring nanoflann, use the nanoflann rosdep package
  The embedded nanoflann.hpp installed by mrpt_libbase clashes with the
  standalone nanoflann ROS package (both install to the same include path).
  Disable MRPT_INSTALL_EMBEDDED_nanoflann in mrpt_libbase and depend on the
  nanoflann rosdep key instead, so MRPT's find_package(nanoflann) picks up
  the system/rosdep copy. mrpt_libmath and mrpt_libtclap also need the
  dependency directly since they either expose nanoflann.hpp in a public
  header (mrpt-math) or have no mrpt_lib* dependency chain to inherit it
  from (mrpt_libtclap).
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

- No changes

## mrpt_libmath

```
* mrpt_libbase: stop vendoring nanoflann, use the nanoflann rosdep package
  The embedded nanoflann.hpp installed by mrpt_libbase clashes with the
  standalone nanoflann ROS package (both install to the same include path).
  Disable MRPT_INSTALL_EMBEDDED_nanoflann in mrpt_libbase and depend on the
  nanoflann rosdep key instead, so MRPT's find_package(nanoflann) picks up
  the system/rosdep copy. mrpt_libmath and mrpt_libtclap also need the
  dependency directly since they either expose nanoflann.hpp in a public
  header (mrpt-math) or have no mrpt_lib* dependency chain to inherit it
  from (mrpt_libtclap).
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

```
* mrpt_libbase: stop vendoring nanoflann, use the nanoflann rosdep package
  The embedded nanoflann.hpp installed by mrpt_libbase clashes with the
  standalone nanoflann ROS package (both install to the same include path).
  Disable MRPT_INSTALL_EMBEDDED_nanoflann in mrpt_libbase and depend on the
  nanoflann rosdep key instead, so MRPT's find_package(nanoflann) picks up
  the system/rosdep copy. mrpt_libmath and mrpt_libtclap also need the
  dependency directly since they either expose nanoflann.hpp in a public
  header (mrpt-math) or have no mrpt_lib* dependency chain to inherit it
  from (mrpt_libtclap).
* Contributors: Jose Luis Blanco-Claraco
```
