### PR TITLE
elite_robots_description: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2791,6 +2791,21 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  elite_robots_description:
+    doc:
+      type: git
+      url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Description.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Description-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Description.git
+      version: humble
+    status: developed
   ess_imu_driver2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_robots_description` to `1.0.0-1`:

- upstream repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Description.git
- release repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## elite_robots_description

```
* Initial release for ROS 2 Humble.
* Added Xacro and URDF descriptions for the Elite Robots CS and LS series,
  including CS63, CS66, CS66A, CS68, CS612, CS616, CS618F, CS620, CS625,
  CS520H, and LS65.
* Added joint limits, kinematic, physical, and visual parameters for the
  supported robot models.
* Added visual and collision meshes, RViz2 configuration, and a launch file
  for inspecting robot descriptions.
* Added support for safety limits, TF prefixes, ros2_control integrations,
  simulated hardware, and configurable initial joint positions.
* Added tests for Xacro/URDF generation and the robot description launch file.
```
