### PR TITLE
popf: 0.0.20-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6557,6 +6557,21 @@ repositories:
       url: https://github.com/MetroRobots/polygon_ros.git
       version: main
     status: developed
+  popf:
+    doc:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: lyrical-devel
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/popf-release.git
+      version: 0.0.20-1
+    source:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: lyrical-devel
+    status: maintained
   pose_cov_ops:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `popf` to `0.0.20-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/ros2-gbp/popf-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## popf

```
* Fixes a bug that appears now with newer C++ versions
* Contributors: Francisco Martín Rico
```
