### PR TITLE
pluginlib: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6232,7 +6232,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `6.0.1-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.0-1`

## pluginlib

```
* std::format, concepts, range-for using and string_view (#298 <https://github.com/ros/pluginlib/issues/298>)
* use C++ 20 in default (#297 <https://github.com/ros/pluginlib/issues/297>)
* Removed dead code (#299 <https://github.com/ros/pluginlib/issues/299>)
* Contributors: Alejandro Hernández Cordero
```

## ros2plugin

- No changes
