### PR TITLE
cascade_lifecycle: 2.0.4-4 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1147,7 +1147,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 2.0.4-3
+      version: 2.0.4-4
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `2.0.4-4`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/ros2-gbp/cascade_lifecycle-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.4-3`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Fix deprecation of ament_target_dependencies
* Contributors: Francisco Martín Ricoo, David Lu, Alejandro Hernández Cordero
```

## rclpy_cascade_lifecycle

- No changes
