### PR TITLE
geometry2: 0.45.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2748,7 +2748,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.45.8-1
+      version: 0.45.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.45.9-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.45.8-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Add generated version header for tf2_ros (backport #955 <https://github.com/ros2/geometry2/issues/955>) (#956 <https://github.com/ros2/geometry2/issues/956>)
* Merge pull request #950 <https://github.com/ros2/geometry2/issues/950> from ros2/mergify/bp/lyrical/pr-949
* Change constructor overloads to sidestep uncrustify differences (#949 <https://github.com/ros2/geometry2/issues/949>)
* Contributors: Janosch Machowinski, Michael Carroll, mergify[bot]
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
