### PR TITLE
rmw_fastrtps: 9.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7612,7 +7612,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.5.1-1
+      version: 9.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.5.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.5.1-1`

## rmw_fastrtps_cpp

```
* Fix buffer-aware subscriptions to preserve unread data across rmw_wait calls (#900 <https://github.com/ros2/rmw_fastrtps/issues/900>)
* Fix transient-local publishing for buffer-aware path (#898 <https://github.com/ros2/rmw_fastrtps/issues/898>)
* use C++ 20 in default. (#894 <https://github.com/ros2/rmw_fastrtps/issues/894>)
* Serialize encapsulation header on buffer aware topics (#891 <https://github.com/ros2/rmw_fastrtps/issues/891>)
* Contributors: CY Chen, Miguel Company, Tomoya Fujita
```

## rmw_fastrtps_dynamic_cpp

```
* use C++ 20 in default. (#894 <https://github.com/ros2/rmw_fastrtps/issues/894>)
* Contributors: Tomoya Fujita
```

## rmw_fastrtps_shared_cpp

```
* Fix buffer-aware subscriptions to preserve unread data across rmw_wait calls (#900 <https://github.com/ros2/rmw_fastrtps/issues/900>)
* use C++ 20 in default. (#894 <https://github.com/ros2/rmw_fastrtps/issues/894>)
* Contributors: CY Chen, Tomoya Fujita
```
