### PR TITLE
rclcpp: 32.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7202,7 +7202,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 32.0.1-1
+      version: 32.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `32.0.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `32.0.1-1`

## rclcpp

```
* Add test for transient-local delivery with unbounded uint8 messages (#3195 <https://github.com/ros2/rclcpp/issues/3195>) (#3202 <https://github.com/ros2/rclcpp/issues/3202>)
* add support for reentrant callback group to EventsCBGExecutor (#3178 <https://github.com/ros2/rclcpp/issues/3178>) (#3200 <https://github.com/ros2/rclcpp/issues/3200>)
* Contributors: mergify[bot]
```

## rclcpp_action

```
* Bugfix/rclcpp action UUID rng race condition (#3183 <https://github.com/ros2/rclcpp/issues/3183>) (#3188 <https://github.com/ros2/rclcpp/issues/3188>)
* Contributors: mergify[bot]
```

## rclcpp_components

```
* Check for association with an executor before removing nodes in ComponentManager (#3190 <https://github.com/ros2/rclcpp/issues/3190>) (#3199 <https://github.com/ros2/rclcpp/issues/3199>)
* Contributors: mergify[bot]
```

## rclcpp_lifecycle

- No changes
