### PR TITLE
cascade_lifecycle: 2.0.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1147,7 +1147,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 2.0.4-3
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `2.0.6-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/ros2-gbp/cascade_lifecycle-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.4-3`

## cascade_lifecycle_msgs

```
* Merge pull request #21 <https://github.com/fmrico/cascade_lifecycle/issues/21> from ahcorde/ahcorde/rolling/fix_dependency
  Fixed rclpy_cascade_lifecycle package.xml
* updated CMakeLists.txt
* Contributors: Alejandro Hernandez Cordero, Francisco Martín Rico
```

## rclcpp_cascade_lifecycle

```
* Merge pull request #21 <https://github.com/fmrico/cascade_lifecycle/issues/21> from ahcorde/ahcorde/rolling/fix_dependency
  Fixed rclpy_cascade_lifecycle package.xml
* updated CMakeLists.txt
* Contributors: Alejandro Hernandez Cordero, Francisco Martín Rico
```

## rclpy_cascade_lifecycle

```
* Update to rolling
* Merge pull request #21 <https://github.com/fmrico/cascade_lifecycle/issues/21> from ahcorde/ahcorde/rolling/fix_dependency
  Fixed rclpy_cascade_lifecycle package.xml
* Fixed rclpy_cascade_lifecycle package.xml
* Contributors: Alejandro Hernandez Cordero, Francisco Martín Rico
```
