### PR TITLE
locator_ros_bridge: 2.1.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5515,10 +5515,11 @@ repositories:
       packages:
       - bosch_locator_bridge
       - bosch_locator_bridge_utils
+      - bosch_navigator_bridge
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.15-1
+      version: 2.1.16-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.16-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.15-1`

## bosch_locator_bridge

```
* update to Locator v2.1 #82 <https://github.com/boschglobal/locator_ros_bridge/issues/82> from boschglobal/humble-v2.1
* CMake: remove boost (#80 <https://github.com/boschglobal/locator_ros_bridge/issues/80>)
* Contributors: Guilhem Saurel, Sheung Ying Yuen-Wille
```

## bosch_locator_bridge_utils

```
* Declare nav2_common as a runtime dependency (#83 <https://github.com/boschglobal/locator_ros_bridge/issues/83>)
* Contributors: Plumezz
```

## bosch_navigator_bridge

```
* Use the same version for navigator bridge #84 <https://github.com/boschglobal/locator_ros_bridge/issues/84> from boschglobal/use-the-same-version
* Remove unneeded packages from cmake (#78 <https://github.com/boschglobal/locator_ros_bridge/issues/78>)
* Clean up paramters section in bosch_navigator_bridge README
* Initial release of bosch_navigator_bridge package (#75 <https://github.com/boschglobal/locator_ros_bridge/issues/75>)
* Contributors: Fabian König, Sheung Ying Yuen-Wille
```
