### PR TITLE
ros2_planning_system: 3.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8215,6 +8215,39 @@ repositories:
       url: https://github.com/selfpatch/ros2_medkit.git
       version: main
     status: developed
+  ros2_planning_system:
+    doc:
+      type: git
+      url: https://github.com/PlanSys2/ros2_planning_system.git
+      version: lyrical-devel
+    release:
+      packages:
+      - plansys2
+      - plansys2_bringup
+      - plansys2_bt_actions
+      - plansys2_core
+      - plansys2_domain_expert
+      - plansys2_executor
+      - plansys2_lifecycle_manager
+      - plansys2_msgs
+      - plansys2_pddl_parser
+      - plansys2_planner
+      - plansys2_popf_plan_solver
+      - plansys2_problem_expert
+      - plansys2_support_py
+      - plansys2_terminal
+      - plansys2_tests
+      - plansys2_tools
+      - plansys2_tui_cli
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_planning_system-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/PlanSys2/ros2_planning_system.git
+      version: lyrical-devel
+    status: developed
   ros2_robotiq_gripper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `3.1.0-1`:

- upstream repository: https://github.com/PlanSys2/ros2_planning_system.git
- release repository: https://github.com/ros2-gbp/ros2_planning_system-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## plansys2

```
* Remove nav2_common dependency
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo
```

## plansys2_bringup

```
* Set C++23 as default
* Fix formats
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_bt_actions

```
* Fix deprecated get_share_directory
* Support custom messages in BTAction via out_msg blackboard
  Read out_msg from the BT blackboard and use it as the status string
  in send_feedback() and finish() calls. Falls back to the default
  generic messages when out_msg is empty. This allows BT action nodes
  to forward custom context (e.g. perception events) through the
  action hub.
* Fix publish execution Info. TUI and CLI
* Deprecate BTAction with rate. Fix all warnings
* Fix test
* Set C++23 as default
* fix: target cancel handle
  More improvments in BTActionNode
* Fix default  server_timeout
* Fix Groot2 monitor format
* Fix tests
* Added callback group executor
* Return to IDLE when finished
* Add tf2_geometry_msgs to plansys2_bt_actions package.xml
  Add tf2_geometry_msgs to plansys2_bt_actions package.xml.
  tf2_geometry_msgs is required to build plansys2_bt_actions
* Use geometry_msgs::msg::Pose as Pose2D is now in vision_msgs
* Fix BTService and BT-JSON
* Update BTServiceNode.hpp
* Added a BT for services
* Added JSON utils
* Revert lifecycle
* Added deprecated constructor
* Remove nolint
* Added spin to test
* Fix some bt _action tests
* Added bt_loop_duration to the blackboard
* Remove rate of ActionExecutorClient constructor and set as default parameter
* Added wait_for_service_timeout param and blackboard
* Added server_timeout as parameter and blackboard
* Doc for bt actions
* Update Readme
* Added Groot2 monitor
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, avalen2022
```

## plansys2_core

```
* Fix deprecated get_share_directory
* Potential fix for pull request finding
  Co-authored-by: Copilot Autofix powered by AI <mailto:175728472+Copilot@users.noreply.github.com>
* Fix data races, optional access crash, and execvp UB in plansys2_core / plansys2_terminal
* Set C++23 as default
* Temporal deactivation of problematic tests
* Add function to print predicates for debugging
* core: tests use std::fs, so include it
* improve documentation State and DerivedResolutionGraph
* rm old ActionVariant from ActionExecutor and adjust code
* 🎨 fix code style
* add State class
* add DerivedResolutionGraph
* add NodeVariant class
* add Action class
* add Derived class and hashes
* add == operator to Instance and Predicate
* Improve doc for core
* Doc for core
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, gavanderhoorn
```

## plansys2_domain_expert

```
* Fix deprecated get_share_directory
* Deprecate BTAction with rate. Fix all warnings
* Set C++23 as default
* change variable name in getDerivedFromDomain
* include DerivedResolutionGraph.hpp in DomainExpert.hpp
* Improve doc for domain and problem
* Improve doc for Domain
* Doc for domain expert
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_executor

```
* Fix deprecated get_share_directory
* Fix publish execution Info. TUI and CLI
* Deprecate BTAction with rate. Fix all warnings
* Fix  performer hang
* Fix orphan thread bug in ExecutorNode
* Fix test
* Add default
* Set C++23 as default
* Use std::string for BT API
* Remove Eigen dependency export
* adjust simple_btbuilder_tests.cpp
* include Action.hpp in BTBuilder.hpp
* Fix Groot2 monitor format
* Added BTUtils and JSONUtils to ComputeBT and ExecutorNode
* Added blackboard keys for compatibility with other nodes
* Fix formats
* rm old ActionVariant from ActionExecutor and adjust code
* add plansys2::SequentialBTBuilder plugin
* Fix print
* fix code style
* Merge branch 'rolling' into getExpr
* Merge branch 'rolling' into getExpr
* Added deprecated constructor
* Merge branch 'PlanSys2:rolling' into fix_predicate_parsing
* Minor fixes
* Added explicit to constructor
* Remove rate of ActionExecutorClient constructor and set as default parameter
* Minor fix
* Doc for executor
* Added Groot2 monitor
* Merge branch 'rolling' into getExpr
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_lifecycle_manager

```
* Set C++23 as default
* Doc for lifecycle
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_msgs

```
* msgs: deal with CMake CMP0094
  Bump CMake minimum version to 3.15, as that's where CMP0094 was
  introduced.
  CMake versions lower than 3.15 have trouble locating Python in
  environments where a Python installed in a non-default location should
  be used (such as Conda, Pixi, etc).
* Set C++23 as default
* Merge pull request #372 <https://github.com/PlanSys2/ros2_planning_system/issues/372> from Rezenders/plansys2_core
  Plansys2 core
* add State.msg
* Contributors: Eshan Savla, Francisco Martín Rico, G.A. vd. Hoorn, Gustavo, Gustavo Rezende
```

## plansys2_pddl_parser

```
* Fix deprecated get_share_directory
* Deprecate BTAction with rate. Fix all warnings
* Set C++23 as default
* add more tests to parser
* fix Ground PDDLPrint for constant
* fix node name parsing in Expression.hpp
* fix code style
* Merge branch 'rolling' into getExpr
* add new helper functions
* add check_var_params to checkParamEquality
* small improvements to getPredicates and getFunctions
* improvments to fromStringPredicate
* fix toString exists when negated
* fix toString when node_type is Parameter
* fix Exists parse
* Fix string predicate parsing to handle cases with no parameters
* more fixes
* added test case for no arg predicates
* fix code style
* fromString works for Parameter
* getNodeType works with parameters
* fix bug in getSubExpr
* add parser::pddl::removeOperatorBeforeParenthesis
* getExpr fix parsing for words with hyphen
* Fix string predicate parsing to handle cases with no parameters
* Fixing bug #329 <https://github.com/PlanSys2/ros2_planning_system/issues/329>
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, eshan-savla
```

## plansys2_planner

```
* Fix deprecated get_share_directory
* Deprecate BTAction with rate. Fix all warnings
* Fix test
* Add default
* Set C++23 as default
* Doc for planner
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_popf_plan_solver

```
* Fix deprecated get_share_directory
* Set C++23 as default
* Doc for popf plan solver
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_problem_expert

```
* Deprecate BTAction with rate. Fix all warnings
* Merge pull request #392 <https://github.com/PlanSys2/ros2_planning_system/issues/392> from fmrico/fix_ci_2
  Fix ci 2
* Set C++23 as default
* derived_name.name -> derived_name.predicate.name
* fix evaluate_not test
* Added optional dependency
* Improve doc for domain and problem
* Doc for problem expert
* Merge branch 'rolling' into getExpr
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_support_py

```
* Added some tests
* Added planner in python
* Convert to fully python package
* Added execute_plan to executor
* Added parser, format and lint
* Update logs and parser
* Implement DomainExpertClient, ExecutorClient, PlannerClient, PlannerClient and ProblemExpertClient
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_terminal

```
* Deprecate BTAction with rate. Fix all warnings
* Potential fix for pull request finding
  Co-authored-by: Copilot Autofix powered by AI <mailto:175728472+Copilot@users.noreply.github.com>
* Fix data races, optional access crash, and execvp UB in plansys2_core / plansys2_terminal
* Fix orphan thread bug in ExecutorNode
* Add default
* Set C++23 as default
* Fix context in plansys2_terminal tests
* derived_name.name -> derived_name.predicate.name
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_tests

```
* Fix deprecated get_share_directory
* Deprecate BTAction with rate. Fix all warnings
* Set C++23 as default
* added test case for no arg predicates
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, eshan-savla
```

## plansys2_tools

```
* Adaptation to the new Qt version
* Deprecate BTAction with rate. Fix all warnings
* Fix RQT plugins
* Set C++23 as default
* tools: conditionally include .hpp (vs .h)
  Headers have been renamed in Rolling & Kilted.
* Contributors: Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, gavanderhoorn
```

## plansys2_tui_cli

```
* Fix missing module in plansys2_tui dependencies
* Fix test import
* Fix publish execution Info. TUI and CLI
* Contributors: Francisco Martín Rico, SamueleSandrini
* Fix CI
* Fix CI
* Merge pull request #404 <https://github.com/PlanSys2/ros2_planning_system/issues/404> from JRL-CARI-CNR-UNIBS/rolling-pr-tui
  Fix missing module in plansys2_tui dependencies
* Fix missing module in plansys2_tui dependencies
* Merge pull request #401 <https://github.com/PlanSys2/ros2_planning_system/issues/401> from PlanSys2/tui_and_cli
  Fix publish execution Info. TUI and CLI
* Fix test import
* Potential fix for pull request finding
  Co-authored-by: Copilot Autofix powered by AI <mailto:175728472+Copilot@users.noreply.github.com>
* Potential fix for pull request finding
  Co-authored-by: Copilot Autofix powered by AI <mailto:175728472+Copilot@users.noreply.github.com>
* Fix publish execution Info. TUI and CLI
* Contributors: Francisco Martín Rico, SamueleSandrini
```
