### PR TITLE
jsk_common_msgs: 5.0.1-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3757,6 +3757,19 @@ repositories:
       url: https://github.com/jrl-umi3218/jrl-cmakemodules.git
       version: master
     status: maintained
+  jsk_common_msgs:
+    release:
+      packages:
+      - jsk_common_msgs
+      - jsk_footstep_msgs
+      - jsk_gui_msgs
+      - jsk_hark_msgs
+      - posedetection_msgs
+      - speech_recognition_msgs
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/tork-a/jsk_common_msgs-release.git
+      version: 5.0.1-2
   kdl_parser:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3758,6 +3758,10 @@ repositories:
       version: master
     status: maintained
   jsk_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
     release:
       packages:
       - jsk_common_msgs
@@ -3770,6 +3774,12 @@ repositories:
         release: release/lyrical/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 5.0.1-2
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `5.0.1-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## jsk_footstep_msgs

```
* Make actionlib_msgs a ROS1-only dependency; ROS2 actions don't need it
* Contributors: Kei Okada
```
