### PR TITLE
pointcloud_conversions: 0.0.4-3 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6514,7 +6514,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/li9i/pointcloud-conversions-release.git
-      version: 0.0.3-1
+      version: 0.0.4-3
     source:
       type: git
       url: https://github.com/li9i/pointcloud-conversions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_conversions` to `0.0.4-3`:

- upstream repository: https://github.com/li9i/pointcloud-conversions.git
- release repository: https://github.com/li9i/pointcloud-conversions-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.3-1`
