### PR TITLE
gz_transport_vendor: 0.3.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3245,7 +3245,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gz_transport_vendor-release.git
-      version: 0.3.4-3
+      version: 0.3.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_transport_vendor` to `0.3.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_transport_vendor.git
- release repository: https://github.com/ros2-gbp/gz_transport_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.4-3`

## gz_transport_vendor

```
* Bump version to 15.1.0 (#21 <https://github.com/gazebo-release/gz_transport_vendor/issues/21>)
* Contributors: Carlos Agüero
```
