### PR TITLE
gz_msgs_vendor: 0.3.4-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3099,7 +3099,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
-      version: 0.3.3-3
+      version: 0.3.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_msgs_vendor` to `0.3.4-2`:

- upstream repository: https://github.com/gazebo-release/gz_msgs_vendor.git
- release repository: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.3-3`

## gz_msgs_vendor

```
* Bump version to 12.0.2 (#17 <https://github.com/gazebo-release/gz_msgs_vendor/issues/17>)
* Contributors: Carlos Agüero
```
