### PR TITLE
prox_mpc: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8122,6 +8122,29 @@ repositories:
       url: https://github.com/fawkesrobotics/protobuf_comm.git
       version: main
     status: developed
+  prox_mpc:
+    doc:
+      type: git
+      url: https://github.com/simone-contorno/prox_mpc.git
+      version: main
+    release:
+      packages:
+      - prox_mpc_benchmark
+      - prox_mpc_controller
+      - prox_mpc_core
+      - prox_mpc_demo
+      - prox_mpc_msgs
+      - prox_mpc_obstacle_tracker
+      - prox_mpc_test_models
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/simone-contorno/prox_mpc-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: main
+      version: main
+    status: developed
   proxsuite:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8129,12 +8129,9 @@ repositories:
       version: main
     release:
       packages:
-      - prox_mpc_benchmark
       - prox_mpc_controller
       - prox_mpc_core
-      - prox_mpc_demo
       - prox_mpc_msgs
-      - prox_mpc_obstacle_tracker
       - prox_mpc_test_models
       tags:
         release: release/jazzy/{package}/{version}
@@ -8142,7 +8139,7 @@ repositories:
       version: 1.0.0-1
     source:
       type: git
-      url: main
+      url: https://github.com/simone-contorno/prox_mpc.git
       version: main
     status: developed
   proxsuite:


### PR DESCRIPTION
Increasing version of package(s) in repository `prox_mpc` to `1.0.0-1`:

- upstream repository: 	https://github.com/simone-contorno/prox_mpc.git
- release repository: https://github.com/simone-contorno/prox_mpc-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## prox_mpc_benchmark

```
* Initial release: scenario-driven benchmarking harness with the standalone
  matrix (mode a/b1, four scenarios x bicycle/unicycle models) and the Nav2
  cross-controller comparison (mode b2) against DWB, MPPI, Graceful, Regulated
  Pure Pursuit, and Vector Pursuit, reusing the ``prox_mpc_demo`` simulation node and
  ``prox_mpc_open`` map and the shared bicycle/unicycle/waffle robots, and
  shipping its own scalable world and Ackermann robot model.
* Live C++ metrics node tapping cross-track/goal error and
  ``SolverDiagnostics``, plus installed Python tooling for orchestration, map
  generation, goal sending, bag reduction, and aggregation.
* Added a ``nav2_core::Controller`` timing decorator (``timing_controller_wrapper``)
  so every controller's per-cycle ``computeVelocityCommands`` compute is
  measured identically, plus fair-tuned per-cycle compute/resource metrics
  (``compute_ms_p50``/``p95``/``max``) alongside the existing CPU/RSS/control-rate
  sampling for the cross-controller comparison.
* ``vector_pursuit_controller`` (apt ``ros-jazzy-vector-pursuit-controller``
  v2.0.0, Apache-2.0) is the comparison's single external fair peer, with a
  ``config/controllers/vector_pursuit.yaml`` preset, the ``exec_depend`` in
  ``package.xml``, and the controller in ``DEFAULT_CONTROLLERS`` in
  ``run_nav2.py`` and in every scenario's ``controllers:`` list.
* Contributors: Simone Contorno
```

## prox_mpc_controller

```
* Initial release: ``nav2_core::Controller`` plugin wrapping the ProxMPC core,
  with global-plan reference building, costmap and predictive obstacle fills, a
  measured-velocity deceleration ramp, and an exact footprint veto.
* Fail-safe escalation to ``NoValidControl`` on a persistent solver failure or a
  persistent footprint veto; structural parameter validation with tuning clamps.
* Added ``max_solve_time`` and ``publish_diagnostics`` defaults to the shipped
  ``prox_mpc_controller.yaml`` config.
* Contributors: Simone Contorno
```

## prox_mpc_core

```
* Initial release: NMPC core solved by a Sequential Quadratic Programming scheme
  over the ProxQP solver, with a pluginlib ``prox_mpc::Model`` base and bundled
  Bicycle / Unicycle models.
* Linearized signed-distance obstacle half-planes with a discrete-time CBF
  coupling and bounded per-node slot capacity.
* Optional wall-clock budget for the SQP loop (fail-safe on overrun).
* Contributors: Simone Contorno
```

## prox_mpc_demo

```
* Initial release: self-contained closed-loop NMPC simulation node (bicycle / unicycle)
  with solve-time benchmarking, plus the Nav2 + Gazebo Harmonic bringup that
  exercises the controller plugin and the obstacle tracker.
* ``config/nav2_prox_mpc_predictive.yaml`` ships the benchmark's validated
  single-/sparse-obstacle preset (``w_weight`` 1000, ``costmap_cost_threshold``
  253, ``cbf_gamma`` 1.0, ``max_obstacles`` 4,
  ``prediction_uncertainty_growth`` 0.05, ``max_dynamic_obstacles`` 2), so the
  demo's predictive path matches the benchmark's measured behavior.
* Contributors: Simone Contorno
```

## prox_mpc_msgs

```
* Initial release: ``Obstacle`` and ``ObstacleArray`` messages for tracked
  dynamic obstacles (id, position, velocity, radius, covariances, and the
  sampled predicted positions with their time step).
* ``SolverDiagnostics`` message: per-control-cycle NMPC/QP solver telemetry
  (solve times, QP status and convergence, SQP/QP iteration counts, residuals,
  objective, max obstacle slack, control period, and deadline/active-obstacle
  signals) for benchmarking; publishers are opt-in.
* Contributors: Simone Contorno
```

## prox_mpc_obstacle_tracker

```
* Initial release: lifecycle node that clusters a 2D ``LaserScan``, associates
  clusters to an IMM (constant-velocity + constant-turn-rate) filter in a fixed
  frame, and publishes a ``prox_mpc_msgs/ObstacleArray``.
* Composable component registration plus a mutually-exclusive callback group and
  teardown guard, so it is safe under a MultiThreadedExecutor; node-only
  ``log_level`` parameter and a standalone launch file.
* Contributors: Simone Contorno
```

## prox_mpc_test_models

```
* Initial release: fault-injection ``prox_mpc::Model`` plugin (``NonFiniteTwist``)
  used by the controller test suite to exercise fail-safe branches through the
  real pluginlib load path.
* Contributors: Simone Contorno
```
