### PR TITLE
gz_rendering_vendor: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3050,7 +3050,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_rendering_vendor` to `0.5.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_rendering_vendor.git
- release repository: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.0-1`

## gz_rendering_vendor

```
* Bump version to 10.0.2 (#20 <https://github.com/gazebo-release/gz_rendering_vendor/issues/20>)
* Contributors: Carlos Agüero
```
