### PR TITLE
v4l2_camera: 0.7.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -13414,7 +13414,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
-      version: 0.7.1-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.7.3-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.1-1`

## v4l2_camera

```
* Make publisher topic(s) reconfigurable
* Fix typo in Raspberry Pi instructions
* Use image_transport to publish using unique_ptr
* Replace ament_target_dependencies with target_link_libraries
* Contributors: Alejandro Hernandez Cordero, Błażej Sowa, Sander G. van Dijk
```
