### PR TITLE
urdfdom: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10907,7 +10907,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 6.0.0-2
+      version: 6.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `6.0.1-1`:

- upstream repository: https://github.com/ros/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.0-2`

## urdfdom

```
* Move the headers from .h to .hpp (#250 <https://github.com/ros/urdfdom/issues/250>)
* Update the minimum build version of the urdfdom_headers (#262 <https://github.com/ros/urdfdom/issues/262>)
* package.xml: add saikishor as maintainer (#261 <https://github.com/ros/urdfdom/issues/261>)
* Contributors: Sai Kishor Kothakota
```
