### PR TITLE
urdfdom_headers: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10923,7 +10923,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 3.0.0-2
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `3.0.1-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-2`

## urdfdom_headers

```
* Move the headers from .h to .hpp (#100 <https://github.com/ros/urdfdom_headers/issues/100>)
* package.xml: add saikishor as maintainer (#107 <https://github.com/ros/urdfdom_headers/issues/107>)
* package.xml: add scpeters as maintainer (#106 <https://github.com/ros/urdfdom_headers/issues/106>)
* Contributors: Sai Kishor Kothakota, Steve Peters
```
