### PR TITLE
rmw_fastrtps: 9.4.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7841,7 +7841,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.8-1
+      version: 9.4.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.9-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.4.8-1`

## rmw_fastrtps_cpp

```
* Fix buffer-aware subscriptions to preserve unread data across rmw_wait calls (#900 <https://github.com/ros2/rmw_fastrtps/issues/900>) (#902 <https://github.com/ros2/rmw_fastrtps/issues/902>)
* Fix transient-local publishing for buffer-aware path (#898 <https://github.com/ros2/rmw_fastrtps/issues/898>) (#901 <https://github.com/ros2/rmw_fastrtps/issues/901>)
* Contributors: mergify[bot]
```

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Fix buffer-aware subscriptions to preserve unread data across rmw_wait calls (#900 <https://github.com/ros2/rmw_fastrtps/issues/900>) (#902 <https://github.com/ros2/rmw_fastrtps/issues/902>)
* Contributors: mergify[bot]
```
