### PR TITLE
NavMap: 0.5.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -27,7 +27,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/EasyNavigation/NavMap-release.git
-      version: 0.4.0-3
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/EasyNavigation/NavMap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `NavMap` to `0.5.1-1`:

- upstream repository: https://github.com/EasyNavigation/NavMap.git
- release repository: https://github.com/EasyNavigation/NavMap-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-3`

## navmap_core

- No changes

## navmap_examples

- No changes

## navmap_ros

- No changes

## navmap_ros_interfaces

- No changes

## navmap_rviz_plugin

- No changes
