### PR TITLE
rqt: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8876,7 +8876,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `2.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-1`

## rqt

- No changes

## rqt_gui

- No changes

## rqt_gui_cpp

```
* Added unit test for Plufin base class (#362 <https://github.com/ros-visualization/rqt/issues/362>)
* fix ROSspinThread shutdown data race and prune unloaded instances (#361 <https://github.com/ros-visualization/rqt/issues/361>)
* drop redundant instance_ member (#360 <https://github.com/ros-visualization/rqt/issues/360>)
* Move implementation from hpp to cpp (#359 <https://github.com/ros-visualization/rqt/issues/359>)
* modernize to cpp20 (#358 <https://github.com/ros-visualization/rqt/issues/358>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
