### PR TITLE
mola_input_rosbag1: 0.3.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4861,7 +4861,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_input_rosbag1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_input_rosbag1` to `0.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_input_rosbag1.git
- release repository: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.0-1`

## mola_input_rosbag1

```
* fix clang-format
* Add use_bag_record_time option for drivers with unsynced header stamps
  Some drivers (observed on TIERS's Ouster and Livox streams) publish
  header.stamp from an internal/relative clock never synced to the
  recording PC's wall clock, which silently breaks ground-truth time
  lookup for every scan. When set on a sensor, the observation's
  timestamp is taken from the bag's own message storage time instead.
* Add support for livox_ros_driver2/CustomMsg too
* Update mrpt_ros_bridge submodule: drop deprecated point-map overloads
  Removes the CPointsMapXYZI/CPointsMapXYZIRT fromROS/toROS overloads,
  which were the source of -Wdeprecated-declarations warnings when
  building Rosbag1Dataset.cpp; CGenericPointsMap already covers the
  same conversions.
* launch: add per-app imgui_app_name for MolaVizImGui
  Sets a unique imgui_app_name in each launch file so Dear ImGui's
  layout persistence stores a separate UI configuration per app.
* Merge pull request #1 <https://github.com/MOLAorg/mola_input_rosbag1/issues/1> from MOLAorg/feature/multi-bag-gt-and-livox-custommsg
  Multi-bag input, ground-truth trajectory API, and Livox CustomMsg support
* fix: validate nav_msgs/Odometry GT quaternion; migrate toPointCloud2 off deprecated point map classes
  - Apply the same non-finite-quaternion guard already used for
  geometry_msgs/PoseStamped to the nav_msgs/Odometry ground-truth branch.
  - Update mrpt_ros_bridge submodule to a commit adding CGenericPointsMap
  fromROS/toROS overloads for sensor_msgs/PointCloud2, and switch
  toPointCloud2() to use them instead of the deprecated
  CPointsMapXYZI/CPointsMapXYZIRT classes.
* refactor: use CGenericPointsMap instead of deprecated CPointsMapXYZIRT in toLivoxCustomMsg
* feat: multi-bag input, ground-truth trajectory API, and Livox CustomMsg support
  - 'rosbag_filename' now accepts a YAML sequence of paths (merged and replayed
  jointly in time order), enabling datasets that ship sensors and ground
  truth in separate .bag files (e.g. BotanicGarden).
  - New 'ground_truth_topic' param pre-scans a geometry_msgs/PoseStamped or
  nav_msgs/Odometry topic into a full trajectory_t, exposed via the
  mola::OfflineDatasetSource ground-truth API (hasGroundTruthTrajectory() /
  getGroundTruthTrajectory()), in addition to normal per-step publishing.
  Malformed poses (e.g. non-finite quaternions) are skipped with a warning
  instead of aborting.
  - Added a livox_ros_driver/CustomMsg -> CObservationPointCloud converter
  (offset_time -> per-point time, reflectivity -> intensity, line -> ring),
  so Livox AVIA-style LiDARs publishing this message type are supported.
  - New mola-cli-launchs/rosbag1_botanicgarden.yaml example wiring all of the
  above for the BotanicGarden dataset's LIO + ground-truth bags.
* feat: support PoseStamped messages
* docs: add ros2 bridge example
* Contributors: Jose Luis Blanco-Claraco
```
