### PR TITLE
autoware_utils: 1.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1184,7 +1184,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_utils-release.git
-      version: 1.7.2-2
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_utils` to `1.9.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_utils.git
- release repository: https://github.com/ros2-gbp/autoware_utils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.2-2`

## autoware_utils

- No changes

## autoware_utils_debug

- No changes

## autoware_utils_diagnostics

- No changes

## autoware_utils_geometry

```
* fix(autoware_utils_geometry): avoid to raise exception if the polygon is empty (#85 <https://github.com/autowarefoundation/autoware_utils/issues/85>)
  * fix: avoid to raise exception if the number of vertices is zero
  * test: fix test not to throw exception
  ---------
  Co-authored-by: Daisuke Nishimatsu <mailto:42202095+wep21@users.noreply.github.com>
  Co-authored-by: Yutaka Kondo <mailto:yutaka.kondo@youtalk.jp>
* Contributors: Kotaro Uetake
```

## autoware_utils_logging

```
* feat(autoware_utils_logging): templatize LoggerLevelConfigure (#113 <https://github.com/autowarefoundation/autoware_utils/issues/113>)
  * templatize loggerlevelconfigure
  * style(pre-commit): autofix
  * fix copilot review
  * fix to include rcutils
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Koichi Imai
```

## autoware_utils_math

- No changes

## autoware_utils_pcl

- No changes

## autoware_utils_rclcpp

```
* feat(autoware_utils_rclcpp): templatize NodeT for get_or_declare_parameter (#112 <https://github.com/autowarefoundation/autoware_utils/issues/112>)
  * templatize NodeT for get_or_declare_parameter
  * style(pre-commit): autofix
  * delete unnecessary comments
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Koichi Imai
```

## autoware_utils_system

- No changes

## autoware_utils_tf

```
* fix(autoware_utils_tf): delete to call SetCreateTimer in tf2_ros path (#114 <https://github.com/autowarefoundation/autoware_utils/issues/114>)
  delete to call CreateTimerInterface
* Contributors: Koichi Imai
```

## autoware_utils_uuid

- No changes

## autoware_utils_visualization

- No changes
