### PR TITLE
autoware_adapi_msgs: 1.9.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -803,7 +803,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_adapi_msgs` to `1.9.2-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_adapi_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.9.1-1`

## autoware_adapi_v1_msgs

```
* docs: add documentation to remaining msg/srv fields (#108 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/108>)
  * add comments
  * Apply suggestion from @youtalk
  * Update autoware_adapi_v1_msgs/perception/msg/ObjectClassification.msg
  ---------
* docs: add unit and range documentation to message fields (#107 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/107>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - PedalsCommand.msg: throttle/brake range (0.0-1.0)
  - SteeringCommand.msg: steering_tire_angle [rad], velocity [rad/s]
  - VelocityFactor.msg: distance [m], field descriptions
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * docs: clarify behavior field accepts user-defined values
  * Update autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
* Contributors: Yutaka Kondo
```

## autoware_adapi_version_msgs

- No changes
