### PR TITLE
autoware_lanelet2_extension: 1.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -954,7 +954,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `1.2.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.0-1`

## autoware_lanelet2_extension

```
* refactor(autoware_lanelet2_extension): add USE_SCOPED_HEADER_INSTALL_DIR (#105 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/105>)
  Co-authored-by: github-actions <mailto:github-actions@github.com>
* feat(lanelet2_format_extension.md): add direction change module's map… (#112 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/112>)
  * feat(lanelet2_format_extension.md): add direction change module's map specifications
  * feat: added direction_change map specifications' illustration and fixed ci errors
  * style(pre-commit): autofix
  * feat: remove lane_change=yes tag specification, add subtype=dashed tag for route traversing through area
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Vishal Chauhan, emmeyteja
```

## autoware_lanelet2_extension_python

```
* refactor(autoware_lanelet2_extension): add USE_SCOPED_HEADER_INSTALL_DIR (#105 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/105>)
  Co-authored-by: github-actions <mailto:github-actions@github.com>
* Contributors: Vishal Chauhan
```
