### PR TITLE
autoware_core: 1.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1007,6 +1007,7 @@ repositories:
       - autoware_behavior_velocity_planner
       - autoware_behavior_velocity_planner_common
       - autoware_behavior_velocity_stop_line_module
+      - autoware_command_gate
       - autoware_component_interface_specs
       - autoware_core
       - autoware_core_api
@@ -1073,7 +1074,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_core-release.git
-      version: 1.8.0-3
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_core` to `1.9.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_core.git
- release repository: https://github.com/ros2-gbp/autoware_core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.8.0-3`

