### PR TITLE
rviz_2d_overlay_plugins: 1.4.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9693,7 +9693,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
-      version: 1.4.1-3
+      version: 1.4.2-1
     source:
       type: git
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_2d_overlay_plugins` to `1.4.2-1`:

- upstream repository: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
- release repository: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.1-3`

## rviz_2d_overlay_msgs

- No changes

## rviz_2d_overlay_plugins

```
* Fix Qt Widgets linkage for display plugins (#28 <https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/28>)
* Adaptions to change in method signature of update() (#30 <https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/30>)
  Distro specific handling of the two different signatures of the update function
* Merge pull request #26 <https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/26> from teamspatzenhirn/moc-sources-qt6-compat
  moc sources and Qt6 compatibility
* add moc output to sources (for automoc) | create compatibility with Qt6 (and Qt5)
* Contributors: Dominik, Henning Klatt, Maximilian Glumann, edward.ix
```
