### PR TITLE
autoware_core: 1.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -852,6 +852,7 @@ repositories:
       - autoware_behavior_velocity_planner
       - autoware_behavior_velocity_planner_common
       - autoware_behavior_velocity_stop_line_module
+      - autoware_command_gate
       - autoware_component_interface_specs
       - autoware_core
       - autoware_core_api
@@ -918,7 +919,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_core-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_core` to `1.9.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_core.git
- release repository: https://github.com/ros2-gbp/autoware_core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.8.0-1`
