### PR TITLE
rig_reconfigure: 1.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9086,7 +9086,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.6.1-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: https://github.com/ros2-gbp/rig_reconfigure-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.6.0-1`

## rig_reconfigure

```
* Fixed distro compatibility from humble to rolling (#47 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/47>)
  * removed backward-ros from package.xml (still kept as optional build dependency)
  * extended CI to check multiple ROS distros
  * switch between get_package_share_path and get_package_share_directory depending on ROS distro
* Contributors: Dominik
```
