### PR TITLE
joint_state_publisher: 2.4.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4693,7 +4693,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.4.1-1
+      version: 2.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.4.3-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.1-1`

## joint_state_publisher

```
* Python3 modernization (#125 <https://github.com/ros/joint_state_publisher/issues/125>)
* fix deprecation warnings (#123 <https://github.com/ros/joint_state_publisher/issues/123>)
* Support Qt5/Qt6 nad minor updates (#122 <https://github.com/ros/joint_state_publisher/issues/122>)
* Contributors: Alejandro Hernández Cordero
```

## joint_state_publisher_gui

```
* Python3 modernization (#125 <https://github.com/ros/joint_state_publisher/issues/125>)
* Added linters to joint_state_publisher_gui (#124 <https://github.com/ros/joint_state_publisher/issues/124>)
* fix deprecation warnings (#123 <https://github.com/ros/joint_state_publisher/issues/123>)
* Support Qt5/Qt6 nad minor updates (#122 <https://github.com/ros/joint_state_publisher/issues/122>)
* Contributors: Alejandro Hernández Cordero
```
