### PR TITLE
roboplan: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7716,7 +7716,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/roboplan-release.git
-      version: 0.5.1-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/open-planning/roboplan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboplan` to `0.6.0-1`:

- upstream repository: https://github.com/open-planning/roboplan.git
- release repository: https://github.com/ros2-gbp/roboplan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.1-1`

## roboplan

```
* Pose constraints in RRT (#278 <https://github.com/open-planning/roboplan/issues/278>)
* Improve Cartesian path planner (#277 <https://github.com/open-planning/roboplan/issues/277>)
* Fix MacOS rpath issues (#275 <https://github.com/open-planning/roboplan/issues/275>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Contributors: Erik Holum, Sebastian Castro
```

## roboplan_cartesian_planning

```
* Improve Cartesian path planner (#277 <https://github.com/open-planning/roboplan/issues/277>)
* Fix MacOS rpath issues (#275 <https://github.com/open-planning/roboplan/issues/275>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Switch OInK backend from OSQP to ProxQP (#259 <https://github.com/open-planning/roboplan/issues/259>)
  Co-authored-by: Sebastian Castro <mailto:sebas.a.castro@gmail.com>
* Contributors: Erik Holum, Sebastian Castro, Sebastian Jahr
```

## roboplan_example_models

```
* Fix MacOS rpath issues (#275 <https://github.com/open-planning/roboplan/issues/275>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Add mujoco_ros2_control option to Franka xacro (#268 <https://github.com/open-planning/roboplan/issues/268>)
* Contributors: Erik Holum, Sebastian Castro
```

## roboplan_examples

```
* Pose constraints in RRT (#278 <https://github.com/open-planning/roboplan/issues/278>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Contributors: Sebastian Castro
```

## roboplan_oink

```
* Improve OInK build times (#273 <https://github.com/open-planning/roboplan/issues/273>)
* Fix MacOS rpath issues (#275 <https://github.com/open-planning/roboplan/issues/275>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Switch OInK backend from OSQP to ProxQP (#259 <https://github.com/open-planning/roboplan/issues/259>)
  Co-authored-by: Sebastian Castro <mailto:sebas.a.castro@gmail.com>
* Fixes for new Ubuntu 26.04 ROS Rolling docker (#269 <https://github.com/open-planning/roboplan/issues/269>)
* Contributors: Erik Holum, Sebastian Castro, Sebastian Jahr
```

## roboplan_rrt

```
* Pose constraints in RRT (#278 <https://github.com/open-planning/roboplan/issues/278>)
* Fix MacOS rpath issues (#275 <https://github.com/open-planning/roboplan/issues/275>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Contributors: Erik Holum, Sebastian Castro
```

## roboplan_simple_ik

```
* Pose constraints in RRT (#278 <https://github.com/open-planning/roboplan/issues/278>)
* Improve joint limit saturation in SimpleIk (#276 <https://github.com/open-planning/roboplan/issues/276>)
* Fix MacOS rpath issues (#275 <https://github.com/open-planning/roboplan/issues/275>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Contributors: Erik Holum, Sebastian Castro
```

## roboplan_toppra

```
* Fix MacOS rpath issues (#275 <https://github.com/open-planning/roboplan/issues/275>)
* Fix Python bindings installs for ROS + Windows (#272 <https://github.com/open-planning/roboplan/issues/272>)
* Windows support through Pixi (#271 <https://github.com/open-planning/roboplan/issues/271>)
* Contributors: Erik Holum, Sebastian Castro
```
