### PR TITLE
septentrio_gnss_driver: 1.4.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9538,7 +9538,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.7-2
+      version: 1.4.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.8-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.7-2`

## septentrio_gnss_driver

```
* Fixes
  
  Fix Aux1 antenna type in INS multi-antenna mode (@Mh-Magdy)
  
  Fix rolling C++20 compatibility (@thomasemter)
  
  Fix incorrect output topic names and message types in README (@vpe-ct2mc)
* Contributors: Mohamed Magdy, @vpe-ct2mc, Thomas Emter, Tibor Dome, septentrio-users
```
