### PR TITLE
roboplan_ros: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7727,6 +7727,17 @@ repositories:
       type: git
       url: https://github.com/open-planning/roboplan-ros.git
       version: main
+    release:
+      packages:
+      - roboplan_ros_cpp
+      - roboplan_ros_examples
+      - roboplan_ros_franka
+      - roboplan_ros_py
+      - roboplan_ros_visualization
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/roboplan_ros-release.git
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/open-planning/roboplan-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboplan_ros` to `0.6.0-1`:

- upstream repository: https://github.com/open-planning/roboplan-ros.git
- release repository: https://github.com/ros2-gbp/roboplan_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## roboplan_ros_cpp

```
* Support macOS and Windows through Pixi (#58 <https://github.com/open-planning/roboplan-ros/issues/58>)
* Add mujoco_ros2_control option and gripper open/close to examples (#57 <https://github.com/open-planning/roboplan-ros/issues/57>)
* Contributors: Sebastian Castro, Erik Holum
```

## roboplan_ros_examples

```
* Support macOS and Windows through Pixi (#58 <https://github.com/open-planning/roboplan-ros/issues/58>)
* Add mujoco_ros2_control option and gripper open/close to examples (#57 <https://github.com/open-planning/roboplan-ros/issues/57>)
* Contributors: Sebastian Castro, Erik Holum
```

## roboplan_ros_franka

```
* Support macOS and Windows through Pixi (#58 <https://github.com/open-planning/roboplan-ros/issues/58>)
* Add mujoco_ros2_control option and gripper open/close to examples (#57 <https://github.com/open-planning/roboplan-ros/issues/57>)
* Contributors: Sebastian Castro, Erik Holum
```

## roboplan_ros_py

- No changes

## roboplan_ros_visualization

```
* Support macOS and Windows through Pixi (#58 <https://github.com/open-planning/roboplan-ros/issues/58>)
* Contributors: Sebastian Castro, Erik Holum
```
