### PR TITLE
rviz_visual_tools: 4.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9504,7 +9504,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_visual_tools-release.git
-      version: 4.1.4-4
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `4.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/ros2-gbp/rviz_visual_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.1.4-4`

## rviz_visual_tools

```
* CMakeLists: dual-support Qt5 and Qt6 (#300 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/300>)
  Select Qt6 when building against rviz 15.1.14 or newer, the release where rviz
  itself switched to Qt6, and keep Qt5 otherwise. ``package.xml`` now uses the
  versionless ``qt-base-dev`` and ``libqtwidgets`` rosdep keys so rosdep installs
  the same Qt that CMake selects.
* tf_visual_tools: pass Node by reference to TransformBroadcaster (#302 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/302>)
  ``tf2_ros::TransformBroadcaster`` removed its deprecated node-pointer
  constructors in tf2_ros 0.46.2.
* Fix additional geometry2 tf2 .h deprecations (#284 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/284>)
* Replace ament_target_dependencies with target_link_libraries (#277 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/277>)
* Raise the minimum CMake version to silence the compatibility deprecation (#287 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/287>)
* ci: unblock and broaden the ros2 matrix for Rolling/Resolute (#301 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/301>)
  Set ``fail-fast: false``, move the rolling job to ``ROS_REPO: testing`` on
  Ubuntu Resolute and mark it non-blocking, and add jazzy, kilted and lyrical
  coverage.
* CI: update actions (#247 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/247>, #249 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/249>, #259 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/259>)
* Update pre-commit hooks (#250 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/250>, #257 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/257>, #273 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/273>)
* [ros2] pass in parent frame for imarker (#233 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/233>)
* Fix unused variables in publishNormalAndDistancePlane (#251 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/251>)
* Clean tf_visual_tools.hpp (#261 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/261>)
* Clean imarker_simple.cpp (#262 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/262>)
* Remove unnecessary .repos file (#245 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/245>)
* Remove outdated build reports from the README (#274 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/274>)
* Contributors: Alejandro Hernández Cordero, Michael Wiznitzer, Nathan Brooks, PPokorski, Robert Haschke, Sebastian Jahr, mosfet80
```
