### PR TITLE
Restore RHEL 8 entries on the Qt5/Qt6-selecting rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6873,7 +6873,7 @@ libqtcore:
     '15.2': null
   rhel:
     '*': [qt6-qtbase]
-    '8': null
+    '8': [qt5-qtbase]
     '9': [qt5-qtbase]
   slackware: [qt6]
   ubuntu:
@@ -6892,7 +6892,7 @@ libqtgui:
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase-gui]
-    '8': null
+    '8': [qt5-qtbase-gui]
     '9': [qt5-qtbase-gui]
   slackware: [qt6]
   ubuntu:
@@ -6917,7 +6917,7 @@ libqtopengl:
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
-    '8': null
+    '8': [qt5-qtbase]
     '9': [qt5-qtbase]
   ubuntu:
     '*': [libqt6opengl6]
@@ -6934,7 +6934,7 @@ libqtsvg:
   openembedded: [qtsvg@meta-qt6]
   rhel:
     '*': [qt6-qtsvg]
-    '8': null
+    '8': [qt5-qtsvg]
     '9': [qt5-qtsvg]
   ubuntu:
     '*': [libqt6svg6]
@@ -6957,7 +6957,7 @@ libqtwidgets:
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
-    '8': null
+    '8': [qt5-qtbase]
     '9': [qt5-qtbase]
   ubuntu:
     '*': [libqt6widgets6]
@@ -9545,7 +9545,7 @@ qt-base-dev:
     '15.2': null
   rhel:
     '*': [qt6-qtbase-devel]
-    '8': null
+    '8': [qt5-qtbase-devel]
     '9': [qt5-qtbase-devel]
   slackware: [qt6]
   ubuntu:
@@ -9563,7 +9563,7 @@ qt-svg-dev:
   openembedded: [qtsvg@meta-qt6]
   rhel:
     '*': [qt6-qtsvg-devel]
-    '8': null
+    '8': [qt5-qtsvg-devel]
     '9': [qt5-qtsvg-devel]
   ubuntu:
     '*': [qt6-svg-dev]


### PR DESCRIPTION
The seven Qt5/Qt6-selecting rosdep keys added in #50896 and #50897 all declare `rhel: '8': null`, so any package depending on them cannot be released for RHEL 8. This PR fills in the RHEL 8 entries with the same Qt5 packages already used for RHEL 9.

### How this surfaced

Releasing `rviz_visual_tools` 4.2.0 to Humble, which switched to `qt-base-dev`/`libqtwidgets` to pick up Qt6 on Resolute. Bloom's `rosrpm` generator for `rhel:8`:

```
Could not resolve rosdep key 'libqtwidgets' for distro '8':
[libqtwidgets] defined as "not available" for OS version [8]
Failed to resolve libqtwidgets on rhel:8 with: Error running generator:
  Failed to resolve rosdep key 'libqtwidgets', aborting.
```

The same package released fine for RHEL 8 previously, using `qtbase5-dev` and `libqt5-widgets`.

### Why the entries are missing

#50896 built these keys by merging existing ones:

> I used gemini to combine the following existing rosdep keys: (and then reviewed it manually)
> `qt6-base-dev`, `qtbase5-dev`, `libqt5-widgets`, `libqt6widgets6t64`

Two of those sources — `qtbase5-dev` and `libqt5-widgets` — have a **flat, unversioned** `rhel:` entry, which covers every RHEL version including 8. Collapsing that into a version-keyed map produced `{'*': qt6, '8': null, '9': qt5}`, dropping RHEL 8. The stated scope was "Rolling (and in the future Lyrical) use Qt5 on RHEL 9 / Ubuntu Noble, and Qt6 everywhere else", where RHEL 8 does not apply, so nothing in review would have flagged it.

So the `null` is an artifact of that collapse, not an assertion that Qt is unavailable on RHEL 8.

### Every value here is already in use on RHEL 8

Each package name below is provided by an existing key whose `rhel:` entry is flat, and therefore already resolves on RHEL 8:

| key | RHEL 8 value added | already provided on RHEL 8 by |
|---|---|---|
| `qt-base-dev` | `qt5-qtbase-devel` | `qtbase5-dev`, `qt5-qmake`, `libqt5-opengl-dev` |
| `libqtwidgets` | `qt5-qtbase` | `libqt5-widgets`, `libqt5-core`, `libqt5-concurrent` |
| `libqtcore` | `qt5-qtbase` | `libqt5-core` |
| `libqtopengl` | `qt5-qtbase` | `libqt5-opengl` |
| `libqtgui` | `qt5-qtbase-gui` | `libqt5-gui` |
| `libqtsvg` | `qt5-qtsvg` | `libqt5-svg` |
| `qt-svg-dev` | `qt5-qtsvg-devel` | `libqt5-svg-dev` |

In every case the new RHEL 8 value is identical to the existing RHEL 9 value, which is the expected outcome: RHEL 8 and 9 both ship Qt5, and only `'*'` (RHEL 10 and newer) has Qt6.

### Scope

All seven members of the family, rather than only the two that blocked our release — the omission is uniform across them and fixing a subset would leave the same failure waiting for the next package. `#52673` is the precedent: it filled the equivalent missing `jammy` entry in `qt-base-dev` so that packages "correctly pick up the Qt5 or Qt6 version of this package, depending on which distro they are running." This is the RHEL 8 half of that same gap.

The other keys in `base.yaml` with `rhel: '8': null` are Qt6-only (`qt6-*`, `libqt6*`, `qml6-module-*`) and are correctly null, since RHEL 8 has no Qt6. They are untouched.

`test/rosdep_formatting_test.py` and `test/rosdep_duplicates_test.py` pass.

Assisted-by: Claude Code:claude-opus-5
