### PR TITLE
moveit_visual_tools: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4916,7 +4916,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_visual_tools-release.git
-      version: 4.1.2-2
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `4.2.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/ros2-gbp/moveit_visual_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.1.2-2`

## moveit_visual_tools

```
* Fix Rolling build: replace ament_target_dependencies + guard the ament_index_cpp header rename (#156 <https://github.com/moveit/moveit_visual_tools/issues/156>)
  Rolling removed ``ament_target_dependencies``; migrate the library and demo
  targets to ``target_link_libraries`` with imported targets. Along with it:
  
    * Declare ``geometric_shapes``, ``moveit_msgs`` and ``ament_index_cpp``, all
      used directly but resolved until now only through the transitive tree that
      ``ament_target_dependencies`` flattened onto every target. Closes
      #155 <https://github.com/moveit/moveit_visual_tools/issues/155>.
    * Guard the ``ament_index_cpp`` header rename — 1.14 removed
      ``get_package_share_directory.hpp`` in favour of ``get_package_share_path``.
    * Link ``moveit_ros_planning::moveit_planning_scene_monitor`` rather than the
      ``moveit_ros_planning`` umbrella target, which exists only on MoveIt ``main``
      and is absent from every released distro.
  
* Add dependency for moveit_ros_occupancy_map_monitor (#153 <https://github.com/moveit/moveit_visual_tools/issues/153>)
* ci: cover every released distro with binary debs (#157 <https://github.com/moveit/moveit_visual_tools/issues/157>)
  The matrix tested two of the five distros this branch ships to. Replace the
  prebuilt-image jobs with plain binary-deb jobs for humble, jazzy, kilted,
  lyrical and rolling. The lyrical and rolling jobs are non-blocking until
  ``moveit_core`` is published for Ubuntu Resolute.
* CMake: drop boost system (#154 <https://github.com/moveit/moveit_visual_tools/issues/154>)
  Boost.System has been header-only since 1.69, and 1.89 removed the stub
  library that ``find_package(Boost COMPONENTS system)`` still required.
* Bump cmake required version: 3.20 (#152 <https://github.com/moveit/moveit_visual_tools/issues/152>)
* Update .pre-commit-config.yaml (#146 <https://github.com/moveit/moveit_visual_tools/issues/146>)
* Contributors: Guilhem Saurel, Nathan Brooks, mosfet80
```
