### PR TITLE
pick_ik: 1.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6092,7 +6092,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.1.1-2
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pick_ik` to `1.1.3-1`:

- upstream repository: https://github.com/PickNikRobotics/pick_ik.git
- release repository: https://github.com/ros2-gbp/pick_ik-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.1-2`

## pick_ik

```
* Migrate from tl_expected to libexpected-dev system package (#81 <https://github.com/PickNikRobotics/pick_ik/issues/81>)
  ``cpp_polyfills`` 2.0 dropped its ``tl_expected`` sub-package, so the
  ``tl_expected`` rosdep key no longer resolves on Ubuntu Resolute. Depend on
  ``libexpected-dev`` instead, which is available on jammy, noble and resolute
  alike. Required for lyrical and rolling.
* Rolling/lyrical: tf2 .hpp header renames + pick_ik include prefix (#82 <https://github.com/PickNikRobotics/pick_ik/issues/82>)
* ci: switch from custom-container CI to industrial_ci (#83 <https://github.com/PickNikRobotics/pick_ik/issues/83>)
  The pre-baked CI container was frozen at its 2023-12 build and its weekly
  rebuild had been failing and then auto-disabled, so every PR for the past two
  years was tested against an environment that no longer exists. industrial_ci
  installs dependencies fresh per run and follows each distro's current base OS,
  matching the buildfarm and the rest of the MoveIt/PickNik release matrix.
  Rolling now builds against ``ros2-testing`` on Resolute, and ``git`` is
  declared as a ``test_depend`` for the Catch2 ``FetchContent`` step.
* Contributors: LarsNobleo, Nathan Brooks
```
