### PR TITLE
graph_msgs: 0.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3719,7 +3719,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/graph_msgs-release.git
-      version: 0.2.0-6
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/graph_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.2.1-1`:

- upstream repository: https://github.com/PickNikRobotics/graph_msgs.git
- release repository: https://github.com/ros2-gbp/graph_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.0-6`

## graph_msgs

```
No message definitions changed in this release; it is CI, packaging and
licensing only.
* ci: unblock and broaden the ros2 matrix for Rolling/Resolute (#20 <https://github.com/PickNikRobotics/graph_msgs/issues/20>)
  Set ``fail-fast: false``, move the rolling job to ``ROS_REPO: testing`` on
  Ubuntu Resolute and mark it non-blocking, and add jazzy, kilted and lyrical
  coverage. The matrix previously tested two of the five distros this branch
  ships to.
* Update GitHub Actions to use latest versions (#18 <https://github.com/PickNikRobotics/graph_msgs/issues/18>)
* Update the build and format workflows (#15 <https://github.com/PickNikRobotics/graph_msgs/issues/15>)
* Bump the minimum CMake version to 3.10
* Humble CI and formatting updates (#10 <https://github.com/PickNikRobotics/graph_msgs/issues/10>)
* Add LICENSE file (#9 <https://github.com/PickNikRobotics/graph_msgs/issues/9>)
* Contributors: Jafar Abdi, Nathan Brooks, Vatan Aksoy Tezer, mosfet80
```
