### PR TITLE
warehouse_ros: 2.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -14206,7 +14206,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros-release.git
-      version: 2.0.5-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.7-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros2-gbp/warehouse_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.5-1`

## warehouse_ros

```
* Replace outdated tf2 includes (switching from .h to .hpp)
  ``tf2_ros`` removed the deprecated ``.h`` headers, so the public
  ``transform_collection.h`` no longer compiles on Ubuntu Resolute. The
  ``__has_include`` fallback for the ``.h`` spelling goes away with it; every
  supported distro ships the ``.hpp`` headers, humble included.
* CI: Fix CI workflow
* CI: Update GHA (#107 <https://github.com/moveit/warehouse_ros/issues/107>)
* Contributors: Robert Haschke, mosfet80
```
