### PR TITLE
warehouse_ros_sqlite: 1.0.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -11205,7 +11205,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
-      version: 1.0.8-2
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `1.0.9-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.8-2`

## warehouse_ros_sqlite

```
* Use Boost targets in warehouse_ros_sqlite (#62 <https://github.com/moveit/warehouse_ros_sqlite/issues/62>)
  Link the explicit Boost targets — headers for the library, filesystem and
  thread for the tests — instead of the aggregate ``${Boost_LIBRARIES}``.
* ci: unblock and broaden the ros2 matrix for Rolling/Resolute (#63 <https://github.com/moveit/warehouse_ros_sqlite/issues/63>)
  Set ``fail-fast: false``, move the rolling job to ``ROS_REPO: testing`` on
  Ubuntu Resolute, and add jazzy, kilted and lyrical coverage. Drops the two
  ``iron`` jobs; iron is EOL and this package is not released to it. The
  previous matrix cancelled every job whenever the rolling one failed, so #62
  reached this release having never been validated by CI.
* Contributors: Nathan Brooks, Tobias Fischer
```
