### PR TITLE
add python rosdep rule for python3-aiofiles

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2867,6 +2867,14 @@ python3-aio-pika-pip:
       pip:
         packages: [aio-pika]
     noble: [python3-aio-pika]
+python3-aiofiles:
+  alpine: [py3-aiofiles]
+  arch: [python-aiofiles]
+  debian: [python3-aiofiles]
+  fedora: [python3-aiofiles]
+  gentoo: [dev-python/aiofiles]
+  rhel: [python3-aiofiles]
+  ubuntu: [python3-aiofiles]
 python3-aiohttp:
   arch: [python-aiohttp]
   debian: [python3-aiohttp]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-aiofiles

## Package Upstream Source:

https://pypi.org/project/aiofiles/

## Purpose of using this:

aiofiles is an Apache2 licensed library, written in Python, for handling local disk files in asyncio applications.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/source/trixie/aiofiles
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/resolute/aiofiles
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-aiofiles/python3-aiofiles/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-aiofiles/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/aiofiles
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-aiofiles
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python-aiofiles (Not available for the image in the CI)
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/python3-aiofiles


