### PR TITLE
navigation2: 1.5.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5525,6 +5525,68 @@ repositories:
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
       version: main
     status: maintained
+  navigation2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: lyrical
+    release:
+      packages:
+      - costmap_queue
+      - dwb_core
+      - dwb_critics
+      - dwb_msgs
+      - dwb_plugins
+      - nav2_amcl
+      - nav2_behavior_tree
+      - nav2_behaviors
+      - nav2_bringup
+      - nav2_bt_navigator
+      - nav2_collision_monitor
+      - nav2_common
+      - nav2_constrained_smoother
+      - nav2_controller
+      - nav2_core
+      - nav2_costmap_2d
+      - nav2_dwb_controller
+      - nav2_graceful_controller
+      - nav2_lifecycle_manager
+      - nav2_loopback_sim
+      - nav2_map_server
+      - nav2_mppi_controller
+      - nav2_msgs
+      - nav2_navfn_planner
+      - nav2_planner
+      - nav2_regulated_pure_pursuit_controller
+      - nav2_ros_common
+      - nav2_rotation_shim_controller
+      - nav2_route
+      - nav2_rviz_plugins
+      - nav2_simple_commander
+      - nav2_smac_planner
+      - nav2_smoother
+      - nav2_system_tests
+      - nav2_theta_star_planner
+      - nav2_util
+      - nav2_velocity_smoother
+      - nav2_voxel_grid
+      - nav2_waypoint_follower
+      - nav_2d_msgs
+      - nav_2d_utils
+      - navigation2
+      - opennav_docking
+      - opennav_docking_bt
+      - opennav_docking_core
+      - opennav_following
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/navigation2-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: lyrical
+    status: developed
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.5.0-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/ros2-gbp/navigation2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
