### PR TITLE
[openembedded]: add python3-junitparser

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5145,6 +5145,7 @@ python3-junitparser:
   fedora:
     '*': [python3-junitparser]
     '42': null
+  openembedded: [python3-junitparser@meta-ros-common]
   ubuntu:
     '*': [python3-junitparser]
     bionic: null


### PR DESCRIPTION
The recipe 'python3-junitparser' is added in meta-ros-common at version 5.0.1 https://github.com/ros/meta-ros/commit/8862f0fbb8e92d358960c431926fd556e55da58e

@robwoolley: could you verify?