### PR TITLE
[openembedded] python[2|3]-netifaces

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1666,7 +1666,6 @@ python-netifaces:
   gentoo: [dev-python/netifaces]
   macports: [p27-netifaces]
   nixos: [pythonPackages.netifaces]
-  openembedded: ['${PYTHON_PN}-netifaces@meta-ros-common']
   opensuse: [python2-netifaces]
   osx:
     pip:
@@ -5834,7 +5833,7 @@ python3-netifaces:
   fedora: [python3-netifaces]
   gentoo: [dev-python/netifaces]
   nixos: [python3Packages.netifaces]
-  openembedded: [python3-netifaces@meta-ros-common]
+  openembedded: [python3-netifaces@meta-python]
   opensuse: [python3-netifaces]
   rhel: ['python%{python3_pkgversion}-netifaces']
   ubuntu: [python3-netifaces]


### PR DESCRIPTION
Remove the not longer exising python2 version

The python3-netifaces is moved to meta-python
see:
  - https://github.com/ros/meta-ros/commit/44cf12b7198b6ca003a81f6dfa6d64c73cab5bb6
  - https://layers.openembedded.org/layerindex/recipe/114061/

@robwoolley: could you verify