### PR TITLE
Add libgit2 and QuaZip rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4292,6 +4292,13 @@ libgirepository-dev:
   gentoo: [dev-libs/gobject-introspection]
   nixos: [gobject-introspection]
   ubuntu: [libgirepository1.0-dev]
+libgit2-dev:
+  alpine: [libgit2-dev]
+  debian: [libgit2-dev]
+  fedora: [libgit2-devel]
+  opensuse: [libgit2-devel]
+  rhel: [libgit2-devel]
+  ubuntu: [libgit2-dev]
 libglew-dev:
   arch: [glew]
   debian: [libglew-dev]
@@ -6964,6 +6971,13 @@ libqtwidgets:
     'focal': null
     'jammy': null
     'noble': [libqt5widgets5t64]
+libquazip1-qt5-dev:
+  debian: [libquazip1-qt5-dev]
+  fedora: [quazip-qt5-devel]
+  ubuntu:
+    '*': [libquazip1-qt5-dev]
+    focal: [libquazip5-dev]
+    jammy: [libquazip5-dev]
 libqwt-qt5-dev:
   arch: [qwt]
   debian: [libqwt-qt5-dev]


### PR DESCRIPTION
This PR adds the following rosdep keys:

- `libgit2`
- `quazip`

The rules map each dependency to the corresponding system package on the supported platforms.

These dependencies are used by Tobas. The rosdep changes have been separated from the Tobas Jazzy release PR as requested in ros/rosdistro#52863.