### PR TITLE
pal_gazebo_worlds: 4.16.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7796,7 +7796,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_gazebo_worlds-release.git
-      version: 4.15.1-1
+      version: 4.16.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gazebo_worlds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gazebo_worlds` to `4.16.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_gazebo_worlds.git
- release repository: https://github.com/ros2-gbp/pal_gazebo_worlds-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.15.1-1`

## pal_gazebo_worlds

```
* uniformed arucos to standard dimension
* Contributors: martinaannicelli
```
