### PR TITLE
tiago_navigation: 4.13.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12785,7 +12785,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_navigation-release.git
-      version: 4.12.0-1
+      version: 4.13.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.13.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/ros2-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.12.0-1`

## tiago_2dnav

```
* adapt eulero migration
* Contributors: antoniobrandi
```

## tiago_laser_sensors

- No changes

## tiago_navigation

- No changes

## tiago_rgbd_sensors

- No changes
