### PR TITLE
tiago_pro_robot: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12878,7 +12878,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_robot-release.git
-      version: 2.4.1-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_robot` to `2.5.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_robot.git
- release repository: https://github.com/ros2-gbp/tiago_pro_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.1-1`

## tiago_pro_bringup

```
* pre grasp motions
* Contributors: matteovillani
```

## tiago_pro_controller_configuration

```
* Control by default the grasping frame
* Fixing pipeline
* fixing pep8
* Adding use_grasping_frame for cartesian controller
* Contributors: matteovillani, vivianamorlando
```

## tiago_pro_description

- No changes

## tiago_pro_robot

- No changes
