### PR TITLE
tiago_robot: 5.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12917,7 +12917,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_robot-release.git
-      version: 4.24.1-1
+      version: 5.1.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `5.1.3-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/ros2-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.24.1-1`

## tiago_bringup

```
* revert not necessary comment on gazebo version
* Contributors: ileniaperrella
```

## tiago_controller_configuration

- No changes

## tiago_description

```
* revert sign on arm_6_joint wrt standards
* revert not necessary comment on gazebo version
* Contributors: ileniaperrella
```

## tiago_robot

- No changes
