### PR TITLE
tiago_simulation: 4.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12935,7 +12935,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_simulation-release.git
-      version: 4.10.1-1
+      version: 4.12.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.12.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/ros2-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.10.1-1`

## tiago_gazebo

```
* start apps using localization manager
* Contributors: antoniobrandi
```

## tiago_simulation

- No changes
