### PR TITLE
tiago_dual_robot: 3.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12741,6 +12741,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_robot.git
       version: humble-devel
+    release:
+      packages:
+      - tiago_dual_bringup
+      - tiago_dual_controller_configuration
+      - tiago_dual_description
+      - tiago_dual_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/tiago_dual_robot-release.git
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_dual_robot` to `3.1.2-1`:

- upstream repository: https://github.com/pal-robotics/tiago_dual_robot.git
- release repository: https://github.com/ros2-gbp/tiago_dual_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## tiago_dual_bringup

```
* add calibration_tool parameter
* Contributors: susannamastromauro
```

## tiago_dual_controller_configuration

- No changes

## tiago_dual_description

```
* add calibration_tool parameter
* Contributors: susannamastromauro
```

## tiago_dual_robot

- No changes
