### PR TITLE
tiago_dual_navigation: 4.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12731,6 +12731,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_navigation.git
       version: humble-devel
+    release:
+      packages:
+      - tiago_dual_2dnav
+      - tiago_dual_laser_sensors
+      - tiago_dual_navigation
+      - tiago_dual_rgbd_sensors
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/tiago_dual_navigation-release.git
+      version: 4.12.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_dual_navigation` to `4.12.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_dual_navigation.git
- release repository: https://github.com/ros2-gbp/tiago_dual_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## tiago_dual_2dnav

```
* adapt eulero refactor
* Contributors: antoniobrandi
```

## tiago_dual_laser_sensors

- No changes

## tiago_dual_navigation

- No changes

## tiago_dual_rgbd_sensors

- No changes
