### PR TITLE
kangaroo_robot: 2.14.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4748,6 +4748,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/kangaroo_robot.git
       version: humble-devel
+    release:
+      packages:
+      - kangaroo_bringup
+      - kangaroo_controller_configuration
+      - kangaroo_description
+      - kangaroo_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/kangaroo_robot-release.git
+      version: 2.14.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/kangaroo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kangaroo_robot` to `2.14.1-1`:

- upstream repository: https://github.com/pal-robotics/kangaroo_robot.git
- release repository: https://github.com/ros2-gbp/kangaroo_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## kangaroo_bringup

```
* Remove unused dependency kangaroo_moveit_config
* Contributors: Noel Jimenez
```

## kangaroo_controller_configuration

- No changes

## kangaroo_description

- No changes

## kangaroo_robot

- No changes
