### PR TITLE
mola: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4590,7 +4590,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `3.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## mola

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* Add mola::TransformTreeSource: expose the /tf tree to other MOLA modules (#188 <https://github.com/MOLAorg/mola/issues/188>)
  * Add mola::TransformTreeSource: expose the /tf tree to other modules
  New mola_kernel interface letting a data source publish its tree of
  coordinate frames, so consumers (e.g. a LiDAR-odometry viewer) can draw a
  robot's joints as it moves. transform_tree(root) returns the subtree below
  'root' with poses already resolved against it.
  The filtering is done in the source, which is what owns the transform
  buffer, so a consumer never receives nor walks unrelated subtrees. The
  interface carries no ROS/tf2 type, keeping mola_kernel ROS-independent.
  Implemented by Rosbag1Dataset (separate repo), Rosbag2Dataset and BridgeROS2.
  No locking is added around the subtree walk: tf2::BufferCore guards its own
  internals, which is also what lets BridgeROS2's TransformListener feed the
  buffer from its own thread.
  * Address review: depth-first comment, cycle guard in the tf walk
  * No need for include guards inside this same git repo
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* fix: ros rolling changed arguments of tf2_ros tf listeners
* fix: GCC error in Rolling due to missing direct rclcpp/Node.hpp include
* totally drop mrpt2 point cloud classes
* Merge pull request #177 <https://github.com/MOLAorg/mola/issues/177> from MOLAorg/feat/rep105-loud-stale-odom-warning
  Make the REP-105 stale-odom fallback loud on first occurrence
* fix(bridge): make the REP-105 stale-odom fallback loud on first occurrence
  When publish_localization_following_rep105 is on and the exact sensor-stamp
  odom->base_link transform is unavailable, the bridge composes map->odom against
  the latest (stale) odom transform. That biases the published TF by the robot's
  motion over the stamp gap (motion-correlated jitter, worst mid-turn), and it is
  the normal path whenever the localizer publishes an estimate extrapolated to
  "now" while odom only exists in the past. The warning was throttled to 60 s,
  which hid this persistent timing violation.
  Emit a loud, explanatory warning the first time the fallback fires, naming the
  consequence and the recommended fix (have the state estimator publish map->odom
  directly via StateEstimationSmoother's publish_map_to_odom_tf, and route the
  bridge TF source filter to that /map_odom method), then continue with the
  throttled steady-state warning so logs are not flooded. No behavior change to
  the published transform itself.
* Contributors: Jose Luis Blanco-Claraco
* fix: ros rolling changed arguments of tf2_ros tf listeners; fixed GCC error in
  Rolling due to missing direct rclcpp/Node.hpp include; dropped MRPT2 point
  cloud classes.
* fix(bridge): REP-105 stale-odom TF fallback now logs a loud, explanatory
  warning the first time it fires (with the recommended fix), instead of only
  a throttled one.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* mola_demos: drop ament_cmake_uncrustify test_depend
  mola_demos has no C/C++ source files (launch files, YAML configs, and
  one Python script only), so ament_uncrustify always finds zero files
  to check. As of ament-uncrustify 0.20.6 that's treated as a failure
  ("No files found", exit 1) rather than a trivial pass, which broke
  the weekly CI build on every ROS distro. lint_cmake/pep257/xmllint
  stay, since those do apply to this package's files.
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_lidar_bin_dataset

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* Add mola::TransformTreeSource: expose the /tf tree to other MOLA modules (#188 <https://github.com/MOLAorg/mola/issues/188>)
  * Add mola::TransformTreeSource: expose the /tf tree to other modules
  New mola_kernel interface letting a data source publish its tree of
  coordinate frames, so consumers (e.g. a LiDAR-odometry viewer) can draw a
  robot's joints as it moves. transform_tree(root) returns the subtree below
  'root' with poses already resolved against it.
  The filtering is done in the source, which is what owns the transform
  buffer, so a consumer never receives nor walks unrelated subtrees. The
  interface carries no ROS/tf2 type, keeping mola_kernel ROS-independent.
  Implemented by Rosbag1Dataset (separate repo), Rosbag2Dataset and BridgeROS2.
  No locking is added around the subtree walk: tf2::BufferCore guards its own
  internals, which is also what lets BridgeROS2's TransformListener feed the
  buffer from its own thread.
  * Address review: depth-first comment, cycle guard in the tf walk
  * No need for include guards inside this same git repo
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Merge pull request #178 <https://github.com/MOLAorg/mola/issues/178> from MOLAorg/feat/rosbag2-compressed-image
  feat: decode sensor_msgs/msg/CompressedImage topics in Rosbag2Dataset
* perf: avoid a redundant image-buffer copy and heap alloc per frame
  Two per-frame savings in toCompressedImage():
  - The temporary sensor_msgs::msg::CompressedImage only needs to live for
  the duration of this call; a stack-local avoids a heap allocation
  cv_bridge::toCvCopy() doesn't require (it takes the message by const
  reference, unlike the raw-Image path's toCvShare(), which needs a
  shared_ptr).
  - cv_ptr (and the cv::Mat it owns) is likewise local to this call, so
  copying it into the CObservationImage with mrpt::img::SHALLOW_COPY
  (ref-counted) instead of DEEP_COPY avoids duplicating the decoded
  pixel buffer a second time.
  Re-verified end-to-end against the Oxford Spires dataset: no errors.
  (CodeRabbit finding on PR #178 <https://github.com/MOLAorg/mola/issues/178>)
* feat: decode sensor_msgs/msg/CompressedImage topics in Rosbag2Dataset
  mrpt_ros_bridge's rosbag2ToImage() only understands the raw,
  uncompressed sensor_msgs/msg/Image wire format, so a 'sensors' entry
  of type CObservationImage pointed at a compressed-image topic (e.g.
  an "image/compressed" republished stream) previously fell through as
  unhandled. Added a local decoder (cv_bridge-based, dispatched on the
  topic's actual wire type) and registered the ROS type for
  auto-detection, so compressed camera streams can be read the same way
  as raw ones.
* Contributors: Jose Luis Blanco-Claraco
* feat: decode sensor_msgs/msg/CompressedImage topics in Rosbag2Dataset.
* perf: avoid a redundant image-buffer copy and heap allocation per frame in
  toCompressedImage().
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Add mola::TransformTreeSource: expose the /tf tree to other MOLA modules (#188 <https://github.com/MOLAorg/mola/issues/188>)
  * Add mola::TransformTreeSource: expose the /tf tree to other modules
  New mola_kernel interface letting a data source publish its tree of
  coordinate frames, so consumers (e.g. a LiDAR-odometry viewer) can draw a
  robot's joints as it moves. transform_tree(root) returns the subtree below
  'root' with poses already resolved against it.
  The filtering is done in the source, which is what owns the transform
  buffer, so a consumer never receives nor walks unrelated subtrees. The
  interface carries no ROS/tf2 type, keeping mola_kernel ROS-independent.
  Implemented by Rosbag1Dataset (separate repo), Rosbag2Dataset and BridgeROS2.
  No locking is added around the subtree walk: tf2::BufferCore guards its own
  internals, which is also what lets BridgeROS2's TransformListener feed the
  buffer from its own thread.
  * Address review: depth-first comment, cycle guard in the tf walk
  * No need for include guards inside this same git repo
* fix formatting
* mola_kernel: don't flood ERROR logs when GUI preview has no viz module
  A launch YAML can populate gui_preview_sensors for a sensor without
  gating that entry behind MOLA_WITH_GUI (several mola_lidar_odometry
  launch files did exactly this). In that case every observation for that
  sensor label enqueued a task that threw and caught "Could not find a
  running MolaViz module" -- thousands of ERROR-level log lines per
  headless run, found via SLAM quality-eval sweeps producing 20k+ of them
  on a single KITTI sequence.
  Check once, outside the per-observation lambda, whether a VizInterface
  is actually running; if not, log a single throttled warning and skip
  enqueueing entirely instead of relying on every launch file getting its
  own MOLA_WITH_GUI gate right.
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* fix: mola_kernel listed mrpt::gui as dependency but could be removed
* Merge pull request #185 <https://github.com/MOLAorg/mola/issues/185> from MOLAorg/chore/remove-keyframe-map-capable
  Remove the KeyframeMapCapable interface
* chore: remove the KeyframeMapCapable interface
  This mixin was introduced to expose per-KF pose plumbing to
  mola_lidar_odometry's trajectory-rebake experiment, which corrected
  accumulated tilt by re-integrating the keyframe chain. That experiment is
  being removed: it was never wired in, and rotating map keyframes without
  transforming the trajectory consistently leaks vertical position.
  The interface had exactly one implementation and no callers, so it is
  removed along with the two methods that existed only for the rebake path,
  oldestActiveKeyframeID() and applyPivotTransform().
  keyframePoses() is kept, since the regroup tests already use it as
  ordinary map API, and the duplicate cloneKFPoses() (whose only difference
  was not being the virtual one) is folded into it.
* Merge pull request #183 <https://github.com/MOLAorg/mola/issues/183> from MOLAorg/feat/child-loggers-console-hook
  Let a module expose child loggers for console capture
* feat(kernel): let a module expose child loggers for console capture
  ExecutableBase gains child_loggers(), an optional hook returning
  additional mrpt::system::COutputLogger instances a module owns but does
  not log through itself (e.g. a library engine run on its own background
  thread). mola_viz_imgui's console window now discovers and hooks these
  the same way it already does for the module itself, tagged with a
  "module/child" source name, so their output is captured without the
  owning module having to relay each message through its own logger
  (which would otherwise re-apply the module's own verbosity gating).
  Motivated by mola_mapper's background loop-closure engine
  (mola_sm_loop_closure), which has its own independent logger whose
  output was previously invisible to the imgui console.
* Merge pull request #180 <https://github.com/MOLAorg/mola/issues/180> from MOLAorg/feat/combobox-fixed-width
  GUI: add optional fixed_width to ComboBox (both backends)
* Add optional fixed_width to ComboBox, honored by both GUI backends
  Without it, ImGui::Combo defaults to an item width that scales with
  the window, so short option lists visibly balloon in wide sub-windows
  (seen when packing a ComboBox next to a checkbox in a Row). 0 keeps
  each backend's current auto-sizing behavior.
* Contributors: Jose Luis Blanco-Claraco
* fix: removed unused mrpt::gui dependency and the unused KeyframeMapCapable
  interface (dead code from an abandoned trajectory-rebake experiment).
* feat(kernel): added child_loggers() hook to ExecutableBase so modules can
  expose background-thread loggers for console capture.
* feat: ComboBox GUI widget gained an optional fixed_width parameter (both
  backends).
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* address review comments
* Add k-d tree baking for IncrementalPointCloud + mm-ipc-bake-kdtree tool
  Serializes the incremental k-d tree index alongside an IncrementalPointCloud
  layer's points (TCreationOptions::serialize_kdtree), so it does not have to
  be rebuilt (an O(N log M) bulk build) on every load. Unlike
  KeyframePointCloudMap's baked static trees, nanoflann's incremental index had
  no save/load support at all; this depends on saveIndex()/loadIndex() added
  upstream (nanoflann >= 1.11.0, see the companion nanoflann PR), gated behind
  MOLA_METRIC_MAPS_HAS_INCREMENTAL_KDTREE_BAKE so older builds keep working
  with the option as a documented no-op.
  Serialization always writes/reads the compacted (tombstone-free) point
  order, so baking builds a throwaway index over that exact order rather than
  reusing the live index (whose slots may not match after tombstones/slot
  recycling).
  Adds the mm-ipc-bake-kdtree CLI tool (analogous to mm-kf-bake-kdtrees) and a
  shared mm_cli_utils.h generic layer-iteration helper for it.
  Unit tests cover: bake/load round-trip through memory and through a real
  temporary file, k-d tree parameters differing between bake and load time,
  clearing and re-inserting into a loaded (baked) map, further
  insertions/trims on a loaded map, and serialize_kdtree=false remaining a
  no-op -- all independent of whether this build's nanoflann actually supports
  baking.
* changelog
* chore: document and fix some multithreading issues
* Merge pull request #185 <https://github.com/MOLAorg/mola/issues/185> from MOLAorg/chore/remove-keyframe-map-capable
  Remove the KeyframeMapCapable interface
* docs: drop the KeyframeMapCapable references left behind
* chore: remove the KeyframeMapCapable interface
  This mixin was introduced to expose per-KF pose plumbing to
  mola_lidar_odometry's trajectory-rebake experiment, which corrected
  accumulated tilt by re-integrating the keyframe chain. That experiment is
  being removed: it was never wired in, and rotating map keyframes without
  transforming the trajectory consistently leaks vertical position.
  The interface had exactly one implementation and no callers, so it is
  removed along with the two methods that existed only for the rebake path,
  oldestActiveKeyframeID() and applyPivotTransform().
  keyframePoses() is kept, since the regroup tests already use it as
  ordinary map API, and the duplicate cloneKFPoses() (whose only difference
  was not being the virtual one) is folded into it.
* Merge pull request #184 <https://github.com/MOLAorg/mola/issues/184> from MOLAorg/feat/incremental-pointcloud-map
  feat(metric_maps): add mola::IncrementalPointCloud (incremental k-d tree local map)
* docs: correct the trySetCreationOptions contract
  The k-d tree parameters used to require an empty map, with
  trySetCreationOptions() returning false rather than discarding points.
  It now compacts and rebuilds instead, so it always succeeds and keeps the
  map contents; only the previously returned point indices are invalidated.
  The TCreationOptions docs still described the old behaviour.
* style: apply clang-format-14
* feat(metric_maps): degrade gracefully on distros with an old nanoflann
  The incremental k-d tree index needs nanoflann >= 1.10.0. Previously the
  whole class was compiled out below that, so a YAML naming
  mola::IncrementalPointCloud failed with MRPT's generic "no such registered
  CMetricMap class", which reads like a typo or a missing plugin rather than
  a missing feature.
  Now the class is always declared, compiled and registered; only the k-d
  tree factory is conditional. Without a suitable nanoflann,
  IncrementalKDTree_stub.cpp provides a factory that throws an explanatory
  std::runtime_error naming the version actually found and pointing at
  mola::KeyframePointCloudMap as the alternative. CMake emits a warning at
  configure time instead of a silent status message.
  MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD keeps advertising whether the
  feature is functional, and the unit test is still only built when it is.
  Verified by configuring against the nanoflann 1.9.0 shipped by ROS Humble:
  builds clean, class registers, and construction throws the expected message.
* feat(metric_maps): add mola::IncrementalPointCloud
  A single-global-frame, sliding-window local map for LiDAR (inertial)
  odometry, backed by one incremental self-balancing nanoflann k-d tree
  instead of a static tree rebuilt on every scan.
  It derives from mrpt::maps::CGenericPointsMap, so points arrive through
  the usual insertObservation()/insertAnotherMap() entry points with all
  per-point channels preserved, and the index picks up appended points
  lazily. Points far from the robot are evicted on insertion
  (creationOptions.remove_points_farther_than, a cube half-side), and the
  slots the index reclaims are recycled so storage stays bounded under
  churn. GICP matching is supported via mp2p_icp::NearestPointWithCovCapable
  with lazily computed, cached, plane-regularized per-point covariances.
  This is an odometry local map only: a single global tree cannot absorb a
  loop-closure re-map, so KeyframePointCloudMap remains the choice there.
  Notes:
  - Requires nanoflann >= 1.10.0 (the release that introduced the
  incremental index). The class is simply not built otherwise, gated by
  the CMake-set MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD.
  - nanoflann is included by src/IncrementalKDTree.cpp alone, by absolute
  path and with its namespace renamed, and is never exposed through a
  public header. MRPT bundles its own, usually older, copy of the same
  header and the two differ in non-template entities that share mangled
  names, so letting both reach one program is an ODR violation. Include
  path ordering cannot select ours either: MRPT exports its copy as an
  -isystem directory, and a directory listed both as -I and -isystem is
  deduplicated by GCC in favour of the system entry.
  - Removal is lazy, so the inherited size() counts live plus not-yet-reused
  slots; livePointCount() and compact() expose the live set. Reclaimed
  slots are blanked to NaN so that generic CPointsMap walkers (notably
  insertAnotherMap(), used to copy layers out for visualization) cannot
  resurrect evicted geometry.
  - With async_rebuild the balancing rebuilds run on a background thread.
  Its worker reads the coordinate buffers, so reserve()/resize()/setSize()
  are overridden to wait for it before those can move, and insertion keeps
  spare capacity for one batch so a raw insertPointFast() loop cannot
  reallocate either.
  Tested against a brute-force nearest-neighbour oracle (both index
  variants), for bounded memory under churn, cov2cov pairings,
  serialization round-trip and copy.
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
* chore: documented and fixed some multithreading issues; removed the unused
  KeyframeMapCapable interface and its stale docs.
* feat(metric_maps): added mola::IncrementalPointCloud, a nanoflann-based
  incremental k-d tree local map for LiDAR odometry, with graceful
  degradation on distros with an old nanoflann. Two different thresholds
  apply: the incremental k-d tree itself requires nanoflann >= 1.10.0 (with
  older versions the map falls back to a stub and is unavailable at runtime),
  while baking (creationOptions.serialize_kdtree, mm-ipc-bake-kdtree) and
  loading baked k-d tree indexes additionally require nanoflann >= 1.11.0.
  Thus, with nanoflann 1.10.x only the incremental functionality works, and
  baking is a documented no-op.
* docs: corrected trySetCreationOptions docs to match its new
  compact-and-rebuild (always-succeeds) behavior.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Merge pull request #180 <https://github.com/MOLAorg/mola/issues/180> from MOLAorg/feat/combobox-fixed-width
  GUI: add optional fixed_width to ComboBox (both backends)
* Add optional fixed_width to ComboBox, honored by both GUI backends
  Without it, ImGui::Combo defaults to an item width that scales with
  the window, so short option lists visibly balloon in wide sub-windows
  (seen when packing a ComboBox next to a checkbox in a Row). 0 keeps
  each backend's current auto-sizing behavior.
* Contributors: Jose Luis Blanco-Claraco
* feat: ComboBox GUI widget gained an optional fixed_width parameter (both
  backends).
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz_imgui

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* gui: limit width of the speed rate UI
* Merge pull request #183 <https://github.com/MOLAorg/mola/issues/183> from MOLAorg/feat/child-loggers-console-hook
  Let a module expose child loggers for console capture
* feat(kernel): let a module expose child loggers for console capture
  ExecutableBase gains child_loggers(), an optional hook returning
  additional mrpt::system::COutputLogger instances a module owns but does
  not log through itself (e.g. a library engine run on its own background
  thread). mola_viz_imgui's console window now discovers and hooks these
  the same way it already does for the module itself, tagged with a
  "module/child" source name, so their output is captured without the
  owning module having to relay each message through its own logger
  (which would otherwise re-apply the module's own verbosity gating).
  Motivated by mola_mapper's background loop-closure engine
  (mola_sm_loop_closure), which has its own independent logger whose
  output was previously invisible to the imgui console.
* Merge pull request #180 <https://github.com/MOLAorg/mola/issues/180> from MOLAorg/feat/combobox-fixed-width
  GUI: add optional fixed_width to ComboBox (both backends)
* Add optional fixed_width to ComboBox, honored by both GUI backends
  Without it, ImGui::Combo defaults to an item width that scales with
  the window, so short option lists visibly balloon in wide sub-windows
  (seen when packing a ComboBox next to a checkbox in a Row). 0 keeps
  each backend's current auto-sizing behavior.
* imgui windows: append profile name to window title
* Merge pull request #179 <https://github.com/MOLAorg/mola/issues/179> from MOLAorg/chore/clang-format-viz-handlers
  style: clang-format fix in MolaVizImGui_handlers.cpp
* perf: avoid a redundant image-buffer copy and heap alloc per frame
  Two per-frame savings in toCompressedImage():
  - The temporary sensor_msgs::msg::CompressedImage only needs to live for
  the duration of this call; a stack-local avoids a heap allocation
  cv_bridge::toCvCopy() doesn't require (it takes the message by const
  reference, unlike the raw-Image path's toCvShare(), which needs a
  shared_ptr).
  - cv_ptr (and the cv::Mat it owns) is likewise local to this call, so
  copying it into the CObservationImage with mrpt::img::SHALLOW_COPY
  (ref-counted) instead of DEEP_COPY avoids duplicating the decoded
  pixel buffer a second time.
  Re-verified end-to-end against the Oxford Spires dataset: no errors.
  (CodeRabbit finding on PR #178 <https://github.com/MOLAorg/mola/issues/178>)
* style: clang-format fix in MolaVizImGui_handlers.cpp
  Pre-existing violation on develop (introduced by 3de93af2, whose title
  claims "+ clang-format" but didn't quite match clang-format-14's
  formatting for the multi-clause "else if (init; cond)" statement),
  currently failing CI clang-format-check on develop itself and blocking
  that check from going green on any PR against this repo.
* chore(viz): fixed-width Hz in sensor info overlay + clang-format
* Contributors: Jose Luis Blanco-Claraco
* gui: limited width of the speed-rate UI control; imgui windows now show the
  profile name in their title.
* feat(kernel): console window now captures child-module loggers (e.g.
  background loop-closure engine) via the new child_loggers() hook.
* feat: ComboBox GUI widget gained an optional fixed_width parameter (both
  backends).
* perf: avoided a redundant image-buffer copy and heap allocation per frame in
  toCompressedImage(); fixed a pre-existing clang-format violation blocking
  CI; fixed-width Hz display in the sensor info overlay.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Merge pull request #187 <https://github.com/MOLAorg/mola/issues/187> from MOLAorg/feat/incremental-point-cloud-kdtree-bake
  Bake IncrementalPointCloud's k-d tree index (mm-ipc-bake-kdtree)
* changelog
* Merge pull request #182 <https://github.com/MOLAorg/mola/issues/182> from MOLAorg/fix/yaml-define-outer-wins
  fix(mola_yaml): outer $define wins over a more deeply imported file's own $define
* style: apply clang-format-14 to the outer-wins $define fix
* fix(mola_yaml): outer $define wins over a more deeply imported file's own $define
  Nested $define blocks for the same variable name did not compose the way
  $import sibling overrides do: the more deeply imported file's own $define
  silently won, discarding an outer file's override for that same name. This
  made it impossible for a launcher to retune a hook that a reusable imported
  fragment also $defines its own default for, short of restating the whole
  target key as a literal sibling value.
  consumeDefineBlock() now skips a $define entry whose name is already present
  in the inherited scope, so the scope closest to the document root (or the
  caller's initial variables) has final say, mirroring "environment > $define >
  inline default" one level up. Updated the existing nested-$define test to the
  new (opposite) contract and added a dedicated multi-level $import regression
  test for the exact reusable-fragment shape that surfaced this.
* Merge pull request #181 <https://github.com/MOLAorg/mola/issues/181> from MOLAorg/feat/yaml-define-directive
  mola_yaml: new $define directive to set variables for a subtree
* docs: clarify outer scope only is used to expand vars
* mola_yaml: new $define directive to set variables for a subtree
  Shared pipeline files already expose their tunable settings as
  ${VAR|default} hooks, but until now a launcher had no way to drive them
  from the YAML itself: the value had to come from the real environment.
  Working around that meant duplicating whole blocks after an $import just
  to change one nested field, which is especially painful for values inside a
  YAML sequence, since $import's deep-merge replaces sequences wholesale.
  $define is a map key holding NAME: VALUE pairs that are bound as
  ${NAME} variables for the subtree of the map it appears in, including the
  files pulled in by a sibling $import / $include{}:
  $define:
  MOLA_DESKEW_METHOD: "MotionCompensationMethod::IMU"
  $import: lidar3d-default.yaml
  The bindings go into YAMLParseOptions::variables, so the resolution order
  in parseVars() is unchanged and the effective priority is
  environment > $define > inline |default: a variable exported on the
  command line still overrides the file. This is deliberately not a setenv:
  the scope is the YAML subtree, so nothing leaks into the process
  environment, into $() sub-processes, or into a sibling module's import.
  Since the variable pass runs later over the whole document with the outer
  options, a subtree carrying a $define is expanded eagerly so the
  definitions reach the plain sibling keys too, not only the imported files.
  Includes unit tests and user documentation.
* Contributors: Jose Luis Blanco-Claraco
* feat: new $define YAML directive to bind variables for a subtree
  (including imported files), letting launchers tune shared pipeline
  settings without duplicating blocks.
* fix(mola_yaml): an outer file's $define now correctly wins over a more
  deeply imported file's own $define.
* Contributors: Jose Luis Blanco-Claraco
```
