### PR TITLE
mola_lidar_odometry: 3.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4899,7 +4899,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `3.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## mola_lidar_odometry

```
* fix: keep the local-map render and the IMU worker off the LiDAR critical path (#126 <https://github.com/MOLAorg/mola_lidar_odometry/issues/126>)Moves the local-map render off the LiDAR thread onto its own worker, and
  introduces a dedicated ``imu_state_mtx_`` so the IMU handler no longer
  serializes behind every LiDAR scan via ``state_mtx_``. The render worker now
  deep-copies the map layers under the map mutex and does the expensive
  recolorize/OpenGL build on that private copy, unlocked. On Oxford
  Spires/GrandTour benchmarks this cut ``onLidar`` max latency roughly in
  half (up to ~216 ms -> ~107 ms) and the IMU thread's total blocked time by
  more than half, eliminating the scan-queue backlog. Also exposes
  ``map_update_decimation`` as ``MOLA_GUI_MAP_UPDATE_DECIMATION``.
* Visualize the robot /tf tree in the LO viewer (opt-in) (#125 <https://github.com/MOLAorg/mola_lidar_odometry/issues/125>)Draws the subtree of coordinate frames below a configurable root frame as
  the robot moves (e.g. a legged robot's joint tree), via the new
  ``mola::TransformTreeSource``. Supports excluding frames/subtrees
  (``tf_tree_exclude_frames``), is toggled live from the GUI's View tab, and
  is enabled by default for the GrandTour dataset with its non-body frames
  excluded.
* Add mola-lo-gui-grandtour launch script for the GrandTour dataset (#124 <https://github.com/MOLAorg/mola_lidar_odometry/issues/124>)GrandTour publishes one ROS1 bag per topic, so
  ``lidar_odometry_from_rosbag1.yaml`` now accepts up to three bags replayed
  jointly. The wrapper locates sibling bags from a mission directory and uses
  the dataset's own ``/tf_static`` for sensor extrinsics.
* Gate ``gui_preview_sensors`` entries behind ``MOLA_WITH_GUI`` consistently
  across all launch YAMLs, removing noisy "no running MolaViz module"
  warnings in headless CI runs. Also adds the ``MOLA_WITH_GUI`` headless
  toggle to the remaining ``mola-cli`` launch files.
* Launch scripts for the citrus farm dataset; conslam dataset now also
  accepts ROS2 bags.
* CLI: reduce/disable the batch progress bar; port CLI argument parsing from
  mrpt-tclap to CLI11 (#123 <https://github.com/MOLAorg/mola_lidar_odometry/issues/123>)Adds ``--progress-bar-period`` to control per-scan progress logging (useful
  for Jenkins batch runs), and replaces the legacy TCLAP parser with CLI11,
  preserving all existing flags/defaults while fixing several ``--help``/docs
  discrepancies along the way.
* CI: don't let ``rosdep`` failures on unresolvable packages abort the job
  before the build/test steps run; ``mola-lidar-odometry-cli`` gains
  ``--input-rosbag1`` support (#122 <https://github.com/MOLAorg/mola_lidar_odometry/issues/122>)
  and now accepts a comma-separated bag list for multi-part recordings.
* Add ``lidar3d-gicp-single-filter.yaml``: one decimation filter feeding both
  map and ICP layers instead of two chained ones
  (#121 <https://github.com/MOLAorg/mola_lidar_odometry/issues/121>), plus
  a DLIO-like pipeline, VoxelAverage/forward-alone decimation-axis variants,
  and map-policy leave-one-out/decimation-method ablation pipelines from the
  809 investigation.
* Add ``log_only`` mode for the map-gravity estimator (validate against
  ground truth without feeding back into the map frame) and retry the
  one-shot accelerometer verticality capture on later scans instead of
  giving up permanently.
* fix: deadlock rendering the local map without owning ``state_mtx_``, and a
  related potential deadlock for large maps under the incremental map class
  (#120 <https://github.com/MOLAorg/mola_lidar_odometry/issues/120>).
  Declare ``mola_yaml`` as an explicit dependency (#109 <https://github.com/MOLAorg/mola_lidar_odometry/issues/109>).
* Estimate the map-frame gravity direction online, default off
  (#116 <https://github.com/MOLAorg/mola_lidar_odometry/issues/116>)The verticality reference used by the ICP gravity prior was captured once
  from a single 50 ms accelerometer average and never updated, biasing the
  map frame by up to several degrees. Wires in
  ``mola::imu::MapGravityEstimator``, which continuously solves for gravity
  in the map frame from preintegrated IMU and the odometry's own relative
  attitudes/velocities, and uses it as the prior's ``up_map`` reference. The
  one-shot rigid re-levelling half of this feature was found unsafe on some
  sequences and deferred to a separate experimental branch.
* Add option to hide the current-pose XYZ corner OpenGL object
  (#117 <https://github.com/MOLAorg/mola_lidar_odometry/issues/117>);
  expose the max-range filter as ``MOLA_MAXIMUM_RANGE_FILTER`` and add a
  hybrid cov-to-cov/point-to-point reference pipeline.
* fix: silently-ignored IMU label filter in ``state-estimation-simple.yaml``
  (wrong YAML key), yaw-free rank-2 gravity constraint with self-silencing
  sigma for the ICP solver, removal of the unused trajectory-rebake research
  scaffold, and a CI fix so one broken distro no longer cancels the sibling
  x86_64 jobs (#112 <https://github.com/MOLAorg/mola_lidar_odometry/issues/112>,
  #114 <https://github.com/MOLAorg/mola_lidar_odometry/issues/114>,
  #113 <https://github.com/MOLAorg/mola_lidar_odometry/issues/113>,
  #115 <https://github.com/MOLAorg/mola_lidar_odometry/issues/115>).
* feat: make the GICP local-map class selectable via
  ``${MOLA_LOCALMAP_CLASS}`` between the existing keyframe map and the new
  ``mola::IncrementalPointCloud`` (async k-d tree rebuild off the mapping
  thread) (#111 <https://github.com/MOLAorg/mola_lidar_odometry/issues/111>).
  Expose local-map update time as a plottable metric.
* fix: ICP prior information matrix used MRPT's Euler tangent-index ordering
  instead of the SE(3) Lie tangent mp2p_icp's solver expects, swapping roll
  and yaw in the IMU gravity correction and 2D-lidar constraints
  (#110 <https://github.com/MOLAorg/mola_lidar_odometry/issues/110>).
* fix: honor ``MOLA_WITH_GUI`` for headless runs in the MulRan launcher
  (#108 <https://github.com/MOLAorg/mola_lidar_odometry/issues/108>); six
  launchers were missing ``raw_data_source`` on the state estimator, silently
  disabling every IMU-based factor
  (#107 <https://github.com/MOLAorg/mola_lidar_odometry/issues/107>).
* fix: an ICP debug-file functor was installed unconditionally and took
  priority over ``mp2p_icp``'s own ``MP2P_ICP_GENERATE_DEBUG_FILES`` switch,
  silently disabling native debug-file generation; now only installed when
  one of its own triggers is actually configured
  (#105 <https://github.com/MOLAorg/mola_lidar_odometry/issues/105>).
* Share the keyframe-creation policy between the local map and the simplemap,
  and let it optionally consider a time window instead of pure spatial
  distance, so revisiting an already-mapped area can still spawn the
  keyframes loop closure needs
  (#104 <https://github.com/MOLAorg/mola_lidar_odometry/issues/104>).
* feat: add ``mola-lo-gui-oxford-spires`` helper for the Oxford Spires
  dataset (multi-part rosbag2 stitching, calibration-derived extrinsics)
  (#103 <https://github.com/MOLAorg/mola_lidar_odometry/issues/103>); add
  ``mola-lo-gui-conslam``/``mola-lo-gui-botanicgarden`` helpers with the
  smoother state estimator enabled; expose ``camera_follows_vehicle`` and a
  ``--headless``/``--no-gui`` flag.
* feat(launch): make the localization ``/tf`` publish source overridable
  (``localization_publish_tf_source``), enabling ``map->odom`` to be
  published directly from the state-estimation smoother instead of being
  composed by the bridge from a mismatched-timestamp odom lookup
  (#102 <https://github.com/MOLAorg/mola_lidar_odometry/issues/102>).
* Contributors: Jose Luis Blanco-Claraco
```
