### PR TITLE
sick_safetyscanners2: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11815,7 +11815,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2` to `1.0.5-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2.git
- release repository: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.4-1`

## sick_safetyscanners2

```
* Updated maintainer list in package.xml
* Added error_info_codes from status_overview service to documentation
* Added status_overview service to return additional device status information
* Contributors: Christian Eichmann
```
