### PR TITLE
pal_statistics: 2.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6089,7 +6089,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.8.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.7.0-1`

## pal_statistics

```
* Merge branch 'codex/guard-statistics-publisher-thread' into 'humble-devel'
  Guard publisher thread macros
  See merge request qa/pal_statistics!63
* Guard publisher thread macros
  Avoid dereferencing a missing statistics registry when starting or stopping a publisher thread through the helper macros.
  Most registry-based macros already warn when the registry is not found. Apply the same pattern to START_PUBLISH_THREAD and STOP_PUBLISHER_THREAD so callers fail gracefully instead of crashing on a null registry pointer.
* Contributors: Sai Kishor Kothakota, Tobias Fischer
```

## pal_statistics_msgs

- No changes
