### PR TITLE
nanoflann: 1.12.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5470,7 +5470,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/nanoflann-release.git
-      version: 1.11.0-1
+      version: 1.12.0-1
     source:
       type: git
       url: https://github.com/jlblancoc/nanoflann.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoflann` to `1.12.0-1`:

- upstream repository: https://github.com/jlblancoc/nanoflann.git
- release repository: https://github.com/ros2-gbp/nanoflann-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.11.0-1`

## nanoflann

```
* Merge pull request #312 <https://github.com/jlblancoc/nanoflann/issues/312> from jlblancoc/feat/automate-release-script
  automate release to ensure consistency
* automate release to ensure consistency
* fix: stop asserting exact NN index in bruteforce comparison tests
  Two points can be equidistant (or within float rounding) from a query;
  nanoflann does not guarantee a tie-break order unless
  NANOFLANN_FIRST_MATCH is defined, so comparing indices makes these
  tests flaky whenever a near-tie occurs. Checking the returned distance
  against the brute-force minimum already fully validates correctness.
* Merge pull request #311 <https://github.com/jlblancoc/nanoflann/issues/311> from jlblancoc/fix-potential-ram-run
  fix: ensure background rebuild spans one single thread
* address review
* fix: ensure background rebuild spans one single thread
* Merge pull request #310 <https://github.com/jlblancoc/nanoflann/issues/310> from jlblancoc/feat/install-examples-option
  Add opt-in NANOFLANN_INSTALL_EXAMPLES option
* Add opt-in NANOFLANN_INSTALL_EXAMPLES option
  Lets users who need the example binaries installed opt in via CMake,
  without changing default behavior for the header-only library.
* Contributors: Jose Luis Blanco-Claraco
```
