### PR TITLE
[openembedded] python3-msgpack-numpy: added @meta-ros-common

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5658,6 +5658,7 @@ python3-msgpack-numpy:
     pip:
       packages: [msgpack-numpy]
   nixos: [python3Packages.msgpack-numpy]
+  openembedded: [python3-msgpack-numpy@meta-ros-common]
   opensuse: [python3-msgpack-numpy]
   osx:
     pip:


### PR DESCRIPTION
see: https://github.com/ros/meta-ros/blob/master/meta-ros-common/recipes-devtools/python/python3-msgpack-numpy_0.4.8.bb

@robwoolley: could you verify?