### PR TITLE
mola_input_rosbag1: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6077,7 +6077,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_input_rosbag1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_input_rosbag1` to `0.4.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_input_rosbag1.git
- release repository: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.0-1`

## mola_input_rosbag1

```
* Expose the bag's /tf tree via mola::TransformTreeSource, so other MOLA
  modules can query the subtree of coordinate frames below a given root
  (e.g. a legged robot's joints) with poses resolved against it.
* fix: support missing timestamp channel
* Hide vendored roslz4/xxhash symbols to prevent collision with a system
  libxxhash, which could otherwise corrupt LZ4 checksum verification on
  some distros.
* update ros rolling to u26.04
* Contributors: Jose Luis Blanco-Claraco
```
