### PR TITLE
orbbec_camera_v2: 2.9.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7463,7 +7463,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/orbbec_camera_v2-release.git
-      version: 2.8.6-1
+      version: 2.9.3-1
     source:
       type: git
       url: https://github.com/orbbec/OrbbecSDK_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orbbec_camera_v2` to `2.9.3-1`:

- upstream repository: https://github.com/orbbec/OrbbecSDK_ROS2.git
- release repository: https://github.com/ros2-gbp/orbbec_camera_v2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.6-1`

## orbbec_camera

```
* Update the bundled OrbbecSDK to v2.9.3 and add third-party license files.
* Add enhanced depth and filtering, SDK bag recording/playback, runtime stream and D2C controls, timestamp clock selection, FPS Boost, and LRM obstacle distance publishing.
* Extend Gemini 330 preset import/export and improve device enumeration, network configuration, image publishing, undistortion, parameter validation, and dropped-frame logging.
* Improve Gemini 301 startup stability and fix D2C intrinsics, timestamp CSV recording, and shutdown-time IMU callbacks.
* Deprecate camera-node firmware upgrade parameters in favor of ``firmware_update_tool``.
```

## orbbec_camera_msgs

```
* Add interfaces for device configuration, SDK bag recording, and runtime stream profile control.
```

## orbbec_description

```
* Add URDF models for the Gemini 301 and Gemini 340 series.
```
