### PR TITLE
ur_client_library: 2.14.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11104,7 +11104,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.14.0-1
+      version: 2.14.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.14.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.14.0-1`

## ur_client_library

```
* fix: teardown blocks indefinitely when a reconnect thread is active and the robot is unreachable (#519 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/519>)
* Harden script_reader against vulnerabilities (#546 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/546>)
* Add missing keys to RTDEInvalidKeyException
* Fix OOB read vulnerability in bin parser (#545 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/545>)
* [start_ursim] Offer updating g5 urcap (#543 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/543>)
* Link urcl to rt on non-Apple Unix (#540 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/540>)
* Fix dependencies for bats (#542 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/542>)
* Bump actions/setup-python from 6 to 7 (#541 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/541>)
* Contributors: Felix Exner, Rune Søe-Knudsen, Tobias Fischer, dependabot[bot]
```