### PR TITLE
v4l2_camera: update source and doc versions to distro specific branches

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3940,7 +3940,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: master
+      version: dashing
     release:
       tags:
         release: release/dashing/{package}/{version}
@@ -3949,7 +3949,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: master
+      version: dashing
     status: developed
   variants:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -13444,7 +13444,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -13453,7 +13453,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: rolling
+      version: jazzy
     status: developed
   variants:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -11026,7 +11026,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -11035,7 +11035,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: rolling
+      version: kilted
     status: developed
   variants:
     doc:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11358,7 +11358,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -11367,7 +11367,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: rolling
+      version: lyrical
     status: developed
   variants:
     doc:


### PR DESCRIPTION
Ensure that the source and documentation versions are set to the correct branch rather than rolling, for relevant releases.
