### PR TITLE
NixOS: Make several Qt entries Qt5/6-independent

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6866,7 +6866,7 @@ libqtcore:
     bookworm: [libqt6core6]
   fedora: [qt6-qtbase]
   gentoo: ['dev-qt/qtcore:6']
-  nixos: [qt6.qtbase]
+  nixos: [qt5or6.qtbase]
   openembedded: [qtbase@meta-qt6]
   opensuse:
     '*': [libQt6Core6]
@@ -6888,7 +6888,7 @@ libqtgui:
   fedora: [qt6-qtbase-gui]
   freebsd: [qt6-gui]
   gentoo: ['dev-qt/qtgui:6']
-  nixos: [qt6.qtbase]
+  nixos: [qt5or6.qtbase]
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase-gui]
@@ -6913,7 +6913,7 @@ libqtopengl:
   arch: [qt6-base]
   debian: [libqt6opengl6]
   fedora: [qt6-qtbase]
-  nixos: [qt6.qtbase]
+  nixos: [qt5or6.qtbase]
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
@@ -6930,7 +6930,7 @@ libqtsvg:
   debian: [libqt6svg6]
   fedora: [qt6-qtsvg]
   gentoo: ['dev-qt/qtsvg:6']
-  nixos: [qt6.qtsvg]
+  nixos: [qt5or6.qtsvg]
   openembedded: [qtsvg@meta-qt6]
   rhel:
     '*': [qt6-qtsvg]
@@ -6953,7 +6953,7 @@ libqtwidgets:
   arch: [qt6-base]
   debian: [libqt6widgets6]
   fedora: [qt6-qtbase-gui]
-  nixos: [qt6.qtbase]
+  nixos: [qt5or6.qtbase]
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
@@ -9538,7 +9538,7 @@ qt-base-dev:
   debian: [qt6-base-dev]
   fedora: [qt6-qtbase-devel]
   gentoo: ['dev-qt/qtcore:6', 'dev-qt/qtwidgets:6', 'dev-qt/qttest:6']
-  nixos: [qt6.qtbase]
+  nixos: [qt5or6.qtbase]
   openembedded: [qtbase@meta-qt6]
   opensuse:
     '*': [libqt6-qtbase-devel]
@@ -9559,7 +9559,7 @@ qt-svg-dev:
   debian: [qt6-svg-dev]
   fedora: [qt6-qtsvg-devel]
   gentoo: ['dev-qt/qtsvg:6']
-  nixos: [qt6.qtsvg]
+  nixos: [qt5or6.qtsvg]
   openembedded: [qtsvg@meta-qt6]
   rhel:
     '*': [qt6-qtsvg-devel]


### PR DESCRIPTION
On Ubuntu and RHEL, these entries refer to Qt5 or Qt6 depending on the underlying distribution. In Nix, we build all packages against the same distribution (nixos-unstable), so we have to make this distinction differently. We define the rosdep keys to resolve to package set `qt5or6` and this package set is then defined in nix-ros-overlay as an alias of `qt5` or `qt6` depending on ROS distribution. The `qt5or6` package set is introduced in https://github.com/lopsided98/nix-ros-overlay/pull/905 and will be merged after this PR.

This is similar approach to what we used previously for `python3-qt-bindings`.
