### PR TITLE
generate_parameter_library: 0.7.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3549,7 +3549,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.7.6-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.5-1`

## generate_parameter_library

```
* Silence CMake deprecation warning (#375 <https://github.com/PickNikRobotics/generate_parameter_library/issues/375>)
* Contributors: Christoph Fröhlich
```

## generate_parameter_library_py

- No changes

## parameter_traits

```
* Silence CMake deprecation warning (#375 <https://github.com/PickNikRobotics/generate_parameter_library/issues/375>)
* Contributors: Christoph Fröhlich
```
