### PR TITLE
Remove battery_state_broadcaster

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10176,7 +10176,6 @@ repositories:
       version: main
     release:
       packages:
-      - battery_state_broadcaster
       - battery_state_rviz_overlay
       tags:
         release: release/jazzy/{package}/{version}


### PR DESCRIPTION
ros-controls will take over the package name and has included it into ros2_controllers repository
https://github.com/ros-controls/ros2_controllers/pull/1888#issuecomment-3269570200
https://github.com/ros-controls/ros2_controllers/pull/1888#issuecomment-3669322394
fyi @ottojo 

We need to delete it from rosdistro before bloom-release ros2_controllers