### PR TITLE
Add NixOS entry for libqt6statemachine6

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6824,6 +6824,7 @@ libqt6opengl6t64:
 libqt6statemachine6:
   arch: [qt6-scxml]
   debian: [libqt6statemachine6]
+  nixos: [qt6.qtscxml]
   rhel:
     '*': [qt6-qtscxml-devel]
     '8': null


### PR DESCRIPTION
See https://search.nixos.org/packages?channel=26.05&query=qtscxml#show=qt6.qtscxml. Ubuntu's package is also built from [qt6-scxml](https://packages.ubuntu.com/resolute/libqt6statemachine6).
