### PR TITLE
nanoflann_vendor: 1.12.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6805,6 +6805,21 @@ repositories:
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main
     status: developed
+  nanoflann_vendor:
+    doc:
+      type: git
+      url: https://github.com/jlblancoc/nanoflann.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/nanoflann-release.git
+      version: 1.12.1-1
+    source:
+      type: git
+      url: https://github.com/jlblancoc/nanoflann.git
+      version: master
+    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoflann_vendor` to `1.12.1-1`:

- upstream repository: https://github.com/jlblancoc/nanoflann.git
- release repository: https://github.com/ros2-gbp/nanoflann-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## nanoflann_vendor

```
* docs: badges updates to use nanoflann_vendor
* Merge pull request #313 <https://github.com/jlblancoc/nanoflann/issues/313> from jlblancoc/chore/rename-ros-package-to-nanoflann-vendor
  chore(ros): rename the ROS package to nanoflann_vendor
  Only the ROS package name changes. The CMake package name comes from the
  CMake project, so find_package(nanoflann) keeps working unchanged.
* Contributors: Jose Luis Blanco-Claraco
```
