### PR TITLE
mavros: 2.15.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4446,7 +4446,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.14.0-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.15.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.14.0-1`

## libmavconn

```
* Merge pull request #2259 <https://github.com/mavlink/mavros/issues/2259> from mavlink/docs-refresh
  docs: refresh, refactor extractor
* docs: refresh subpackage READMEs
  - mavros: point the API docs link at readthedocs/plugin reference instead of
  the dead wiki.ros.org page; fix ROS1 roslaunch examples to ros2 launch; note
  that up-to-date install instructions live in the readthedocs guide.
  - mavros_extras: link to the full plugin reference.
  - libmavconn: link to the docs and API reference.
  - mavros_msgs: add the missing README (message/service overview + API links).
  - test_mavros: mark the ROS1-era SITL hand-tests as historical.
* Merge pull request #2256 <https://github.com/mavlink/mavros/issues/2256> from mavlink/try-optimize-router
  Optimize MAVROS router and MAVConn send path
* libmavconn: speed up utils::format with a stack-buffer fast path
  The old format() called snprintf twice (once to measure, once to fill) and
  wrote through &ret.front()/capacity(), which is UB for empty output. Format
  into a small stack buffer first (single snprintf), re-formatting into a heap
  string only when the output exceeds it. Handles encoding errors and the
  empty-output case.
* libmavconn: skip send post when chain active, use composed async_write
  Only the producer that turns the tx queue from idle to active posts a send
  handler; an in-progress chain drains everything enqueued meanwhile. This
  removes the per-message asio::post handler allocation and shared_from_this
  churn on the send path in steady state.
  Use composed asio::async_write for TCP/serial so partial writes are
  handled internally, deleting the manual MsgBuffer::pos tracking and resend
  loop (and the fragile capture of a reference into the tx queue).
* libmavconn: fix serial close deadlock, add serial pair benchmark
  MAVConnSerial::close() held mutex while joining the io thread, while the
  io thread (do_read error handler) blocked on that same mutex -> deadlock.
  Release the mutex before shutdown_owned(), matching UDP/TCP.
  Add a serial throughput benchmark case over a socat PTY,link=... pair
  (stable device paths for both ends), now that the close hang is fixed.
  UDP/TCP/serial pair throughput all benchmark cleanly.
* libmavconn: add tcp pair benchmark, make benchmark standalone
  Add a TCP client/server pair throughput case next to the UDP one, and
  rename the UDP case MavconnUdpBenchmark for naming consistency. The
  benchmark is kept as a standalone executable (not a CI test) because the
  MAVConn async close/shutdown race intermittently hangs the TCP case under
  the test harness; run it manually to check mavconn hot-path regressions.
  A serial (tty) case was attempted over a socat pty pair but dropped: it
  works in isolation yet reproduces the same intermittent close() hang, and
  the pty master has no clean device path for a second MAVConnSerial.
* libmavconn: add end-to-end transport pair benchmark
  A sender/receiver MAVConn UDP pair over loopback measuring sustained
  message throughput through the full send (enqueue + async send) and
  receive (async recv + parse_buffer + callback) paths, to catch mavconn
  hot-path regressions.
* libmavconn: revert pool allocator experiment (benchmark showed it slower)
  benchmark (deque<MsgBuffer> push/pop, ros2-lyrical, 16-core):
  PushPopPlain        ~71 ns/op
  PushPopPool         ~175 ns/op   (~2.5x slower)
  PushPopPlainInline   ~73 ns/op
  PushPopPoolInline   ~185 ns/op   (still ~2.5x slower even when the queue
  fits entirely in the inline chunk)
  The overhead is intrinsic per-op (chunk_of, free_list_ vector ops, in_use
  counters, shrink_if_idle on every release); glibc's tcache malloc/free is
  faster than the hand-rolled pool even for same-size blocks. Restore plain
  std::deque<MsgBuffer>.
* libmavconn: experiment: pool the tx queue MsgBuffer nodes
  Back std::deque<MsgBuffer> with a chunked pool allocator: the first 32
  blocks come from one contiguous inline array (zero alloc), further blocks
  from heap chunks freed when the queue drains back to inline-only. Kept for
  the record only -- see the next commit for why it was rejected.
* build: bump cmake_minimum_required to 3.10
  CMake (4.0+, as shipped on Lyrical/Rolling) emits a deprecation
  warning for cmake_minimum_required < 3.10:
  CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version
  of CMake.
  Raise the floor to 3.10 for all packages that were below it:
  - libmavconn, mavros, mavros_msgs, mavros_extras: 3.5 -> 3.10
  - test_mavros: 2.8.3 -> 3.10
  - mavros_examples: 3.8 -> 3.10
  3.10 is the lowest version that silences the warning while remaining
  compatible with all supported ROS 2 distros (Humble ships CMake 3.22).
* Merge pull request #2242 <https://github.com/mavlink/mavros/issues/2242> from mavlink/followup-terrain-protocol
  extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
* common: reformat py by ruff
* Merge pull request #2105 <https://github.com/mavlink/mavros/issues/2105> from mavlink/refactor-router
  Refactor router
* libmavconn: skip pymavlink e2e as collected-skip, not import-skip
  pytest.importorskip() at module import collects 0 tests, and pytest exits
  with code 5 ('no tests collected') in that case. ament's run_test.py treats a
  non-zero pytest exit as failure, so on CI runners where pymavlink is not
  installed the e2e test was reported as Failed even though nothing ran.
  Use a module-level pytestmark skipif guarded by importlib.util.find_spec so
  the tests are still collected and then skipped (pytest exits 0). Verified:
  with pymavlink present 6/6 pass; with it blocked, 6 collected + skipped,
  exit 0.
* libmavconn: harden pymavlink e2e against UDP startup race
  The e2e test sends a UDP datagram to the link immediately after creating it.
  The link posts its async receive on a worker io thread, so on a loaded or
  slow CI runner the first datagram can arrive before the receive is posted and
  be silently lost, failing the test intermittently (observed in industrial_ci).
  Add a short settle delay in the link fixture so the io thread is up before
  any test traffic. Verified locally: 6/6 pass, full libmavconn suite green.
* ci: gate pymavlink e2e dep on TEST_ENABLE_E2E for rosdep
  The libmavconn e2e test needs pymavlink, which is pip-only. Gate the
  python3-pymavlink-pip test_depend on TEST_ENABLE_E2E=1 so regular
  source-based rosdep installs do not pull a global pip package; only CI
  enables it (TEST_ENABLE_E2E=1 set in both workflows).
  On PEP 668 distros (jazzy/kilted, Python >= 3.11) rosdep's pip installer is
  blocked from installing globally, which previously failed the industrial_ci
  (jazzy) and coverage libmavconn jobs during Install Dependencies. Set
  PIP_BREAK_SYSTEM_PACKAGES=1 alongside so rosdep may install it there.
  The e2e test self-skips via pytest.importorskip where pymavlink is absent.
* libmavconn: add pymavlink-referenced byte-stream e2e test
  Add an end-to-end test that drives a real MAVConnUDP link through a small
  ctypes shim and checks libmavconn's wire encoding/decoding against pymavlink
  as the reference implementation:
  - TX: libmavconn HEARTBEAT is byte-for-byte identical to pymavlink's frame.
  - RX: pymavlink HEARTBEAT and SYS_STATUS (extension fields) decode to exact
  ids/seq/payload.
  - Signing: signed TX verified by pymavlink, signed RX accepted with
  Framing::ok, and a wrong key yields Framing::bad_signature.
  The pytest is guarded by pytest.importorskip("pymavlink") so it skips
  cleanly where the pip package is absent (CI/buildfarm). Add a setup.cfg so
  the new Python file uses the same flake8 style as mavros. Plan documented in
  docs/mavlink-e2e-tests-plan.md.
* libmavconn: updated deprecated asio API (missed few spots in the patch)
* libmavconn: refactored deprecated asio API
* style - apply ament_uncrustify from kilted
* libmavconn: add MAVLink v2 signing support
* docs: update docs
* conn: improve url error handling
* conn: next c++20 modernization pass 3
* conn: next c++20 modernization pass
* conn: fix thread etrmination
* conn: c++20 modernization pass 1
* conn: use common io context runner helper
* conn: resurce usage - use non-recursive mutexes
* conn: reduce lock time in tcp
* conn: reduce lock time
* conn: reduce lock time
* conn: trigger connected out of lock
* conn: reduce locking in tcp
* conn: add test for io-thread
* conn: fix build
* conn: allow to use external io service
* conn: fix almost impossible division by zero
* docs: correct some more typos and spelling erorors
* docs: fix some spelling errors
* Contributors: Tomas Baca, Vladimir Ermakov
```

## mavros

```
* Merge pull request #2259 <https://github.com/mavlink/mavros/issues/2259> from mavlink/docs-refresh
  docs: refresh, refactor extractor
* cog: re-generate all
* mavros: clean up README links
  Fix the broken inline Pixhawk link, point the mavlink dependency at
  mavlink.io instead of the dead wiki.ros.org page, drop unused link references
  (catkin, shadow, boost, iss35, iss856) and upgrade http:// to https://.
* mavros: replace README install section with a link to the docs
  The install instructions are maintained in the readthedocs installation guide;
  point there instead of duplicating (and drifting) binary/source install steps in
  the package README.
* docs: refresh subpackage READMEs
  - mavros: point the API docs link at readthedocs/plugin reference instead of
  the dead wiki.ros.org page; fix ROS1 roslaunch examples to ros2 launch; note
  that up-to-date install instructions live in the readthedocs guide.
  - mavros_extras: link to the full plugin reference.
  - libmavconn: link to the docs and API reference.
  - mavros_msgs: add the missing README (message/service overview + API links).
  - test_mavros: mark the ROS1-era SITL hand-tests as historical.
* docs: remove redundant topic repetitions in plugin docs
  - sim_state: drop the topic list from the class brief; the generated
  Publishers section already lists each topic with a description.
  - Separate section-marker // comments (e.g. "// publishers") from the
  //! entity description with a blank line, so the extractor no longer
  concatenates them into verbose descriptions like "publishers Publish
  DEBUG messages...".
  - Regenerate docs.
* Merge pull request #2258 <https://github.com/mavlink/mavros/issues/2258> from mavlink/plugin-tests
  Plugin tests
* mavros: disable intra-process for latched publishers
  Plugin nodes enable intra-process comms, but rclcpp (e.g. humble) rejects
  creating a latched (transient_local) publisher or subscription on an
  intra-process node: "intraprocess communication allowed only with volatile
  durability". This made the waypoint/geofence/rallypoint/global_position/
  home_position/sys_status plugins (which publish latched state) fail to start
  on humble, and the mission plugin test crash in CI.
  Add NonIntraProcessPublisherOptions()/NonIntraProcessSubscriptionOptions()
  helpers and pass them to the transient_local publishers and subscriptions, so
  those entities opt out of intra-process delivery while volatile topics keep
  the zero-copy path.
* mavros: harden plugin tests against CI-only hangs/crashes
  Fix two classes of failures seen only on the CI runners (not locally):
  - Initialize rclcpp once per test binary instead of per test. Repeated
  rclcpp::init()/shutdown() across the integration tests hung on lyrical and
  rolling CI (FastDDS SHM / context teardown). Add TestUAS::Init() called from
  main() and stop calling shutdown() in the fixture.
  - Match the capture subscription QoS to the sink publisher (best_effort +
  durability_volatile). On humble this avoided the intraprocess-communication
  exception thrown while subscribing in SetUp, which crashed the mission
  suite.
  Also move the pure Parameter conversion tests into a lightweight fixture that
  does not construct the ROS node stack, reducing node churn.
* docs: add ROS API descriptions to all plugins and regenerate docs
  Add one-line //! descriptions for every exposed publisher, subscriber,
  service, client and parameter across all mavros and mavros_extras plugins,
  so the generated per-plugin docs describe what each ROS entity does.
  Regenerate the plugin docs and index, and add a readthedocs Documentation
  badge to the README.
* docs: add mavlink subprotocol references to plugin docs
  Add a reference to the relevant MAVLink microservice (subprotocol) page in
  the doxygen description of each plugin that maps to one. The references flow
  through the existing doc extractor/template pipeline.
* mavros: add service-based plugin tests for command, param, mission
  Add gmock/gtest suites that exercise the exposed ROS API of the command,
  param and waypoint (mission) plugins over real ROS interfaces, using a shared
  TestUAS fixture that captures outbound MAVLink from mavlink_sink and injects
  inbound messages via plugin_route.
  - command (mavros-plugin-command): each ~/cmd service, COMMAND_LONG/INT
  payload, ACK result, ACK timeout, broadcast/non-ACK paths.
  - param (mavros-plugin-param): set/pull/get flows, Parameter conversion,
  set/pull timeouts, excluded/unknown-parameter rejections.
  - mission (mavros-plugin-mission): pull/push/clear/set_current handshakes,
  item retry, push/pull timeouts, partial-push rejection.
  The plugin .cpp files are compiled into the test TUs to keep the approach
  refactor-free where the classes are otherwise internal.
* mission: make timeouts configurable via parameters
  Replace the hardcoded WP_TIMEOUT/LIST_TIMEOUT/RETRIES_COUNT/RESCHEDULE_TIME
  constants in MissionBase with node-declared parameters (mission_wp_timeout,
  mission_list_timeout, mission_retries, mission_reschedule_time) so the
  timeout/retry behavior can be tuned and tested. Recreate the retry wall-timer
  when mission_wp_timeout changes.
* param: make timeouts configurable via parameters
  Replace the hardcoded PARAM_TIMEOUT/LIST_TIMEOUT/RETRIES_COUNT constants
  with node-declared parameters (param_set_timeout, param_list_timeout,
  param_retries) so the timeout/retry behavior can be tuned and tested.
  Recreate the retry wall-timer when param_set_timeout changes.
  Also zero-initialize the mavlink_param_union_t in to_param_set() to avoid
  undefined-behaviour padding bytes leaking into the PARAM_SET payload.
* Merge pull request #2256 <https://github.com/mavlink/mavros/issues/2256> from mavlink/try-optimize-router
  Optimize MAVROS router and MAVConn send path
* mavros: break Router<->Endpoint cycle fully in test teardown
  The reverse-reachability index (remote_index) also holds Endpoint::SharedPtr,
  so clearing only endpoints left the index keeping the endpoints (and the
  Router, via each endpoint's parent) alive. That leaked the Router node -- a
  DDS participant -- which intermittently crashes FastDDS discovery and shows
  up as flaky router termination. Clear remote_index alongside endpoints in
  all router test teardowns.
* mavros: fix lazy index rebuild race, uncrustify select bench
  Clear remote_index_dirty only while holding index_mutex, closing a window
  where a thread that lost the CAS could read the still-empty index and drop
  a message (caught by route_stress_multithreaded_broadcast).
  Reformat test_router_select_benchmark.cpp with uncrustify.
* mavros: add router selection micro-benchmark
  Mock-endpoint benchmark of route_message() in isolation (no DDS publish, no
  real I/O), used to separate the cost of the routing decision from the
  libmavconn send path and the ROS publish path.
* mavros: add reverse reachability index to router
  Replace the per-message endpoint sweep in route_message with a reverse
  index (remote address -> reachable endpoints) guarded by index_mutex.
  The index is rebuilt lazily on use: recv_message and the stale-addr
  cleanup only raise an atomic dirty flag; route_message rebuilds under a
  CAS-gated unique_lock, so the hot read path stays a plain load + shared
  lock with no RMW. add/del keep the index in sync synchronously for
  pointer-lifetime safety. Broadcast lookup is done only when needed.
* mavros: optimize router hot path
  Single-pass target collection removes the second full endpoint scan (and
  second allocation) on the targeted-miss fallback.
  InlineVector (mavros::utils::InlineVector<T, N>) replaces the per-message
  std::vector in route_message with a stack buffer, spilling to heap only for
  large swarms. It is a portable C++20 stand-in for C++23 std::inplace_vector,
  which is unavailable across the supported distro/toolchain matrix.
* Merge pull request #2250 <https://github.com/mavlink/mavros/issues/2250> from mavlink/try-optimize
  Try optimize
* tests: fix uncrustify
* tests: add router e2e and benchmark suites
  Replace the gtest benchmark (duplicated mock coverage) with a real UDP
  e2e test (test_router_e2e.cpp) that exercises GCS broadcast to all FCUs,
  FCU broadcast to GCS, targeted UAS routing, and UAS broadcast to GCS +
  FCUs.  The Google Benchmark (test_router_benchmark.cpp) measures sustained
  throughput (~67k msg/s, 100% delivery) and is gated by the CMake option
  AMENT_RUN_PERFORMANCE_TESTS.
  Both use plain asio (matching libmavconn) instead of Boost.Asio, so they
  build on humble where standalone and Boost asio headers collide.
  ament_cmake_google_benchmark is now a REQUIRED test dependency.
* uas: default UAS executor threads to clamp(2, 4)
  The plugin executor only runs a handful of subscription callbacks per
  UAS; spinning up one thread per core (up to 16) wastes resources,
  especially with several UAS nodes. Clamp the default to 2-4 threads
  (hardware_concurrency still overrides). MAVROS_UAS_EXECUTOR_THREADS
  keeps working as an explicit override.
* mavros: zero-copy publish, memoize endpoint frame_id
  Publish mavros_msgs::msg::Mavlink via unique_ptr so intra-process
  subscribers (UAS/router) receive the buffer without a copy, and hand the
  source endpoint's frame_id through the send path.
  ROSEndpoint::send_message() and UAS::send_message() now publish a
  message built in-place; the router memoizes each endpoint's "ep:<id>"
  frame_id once in set_id() instead of formatting it on every message, and
  passes it down instead of the raw endpoint id. The Endpoint send_message
  signature changes accordingly (test_router mock updated).
* mavros: prohibit UAS copy/move semantics
  UAS owns an executor thread, TF listeners, subscriptions and plugin
  nodes, so copying it (still implicitly generated because of the
  user-declared destructor) would be a bug. Delete copy and move (as in
  PR #1961 <https://github.com/mavlink/mavros/issues/1961>). Nothing in the codebase copies or moves a UAS.
* mavros: fix ownership comment, document executor flags and composable launch
  Clarify the plugin<->UAS ownership comment (UAS owns the plugins, so the
  plugins must not own the UAS). Document MAVROS_EXECUTOR_TYPE and
  MAVROS_UAS_EXECUTOR_THREADS env vars and the test_compose.launch.py
  arguments in mavros/README.md.
* mavros: enable intra-process comms, harden composable launch
  Enable use_intra_process_comms(true) for the mavros_node container and
  the dynamically created plugin nodes, so the internal MAVLink bus and
  co-located subscribers go zero-copy (cross-process consumers fall back
  to DDS, so this is safe either way).
  test_compose.launch.py:
  - fcu_url/gcs_url as launch arguments instead of hardcoded URLs
  - add an 'executor' argument (mt by default, events/auto opt-in). The
  Callback Group Events executor's component-container support is still
  immature upstream (ros2/rclcpp#3186 <https://github.com/ros2/rclcpp/issues/3186>: shutdown double-remove;
  ros2/rclcpp#3123 <https://github.com/ros2/rclcpp/issues/3123>: container support), so default to the reliable
  component_container_mt and only use component_container
  --executor-type events-cbg when asked
  - resolve URLs in an OpaqueFunction so list parameters keep their type
  - tone down container log level from DEBUG to INFO
* mavros: fix composable node ownership cycle and plugin naming
  Two fixes so mavros::router::Router and mavros::uas::UAS work cleanly as
  composable nodes in a component container:
  1. Break the plugin <-> UAS ownership cycle. Plugin held a shared_ptr to
  the UAS node while the UAS node owned the plugins, so on component
  unload the nodes were never destroyed (they lingered and got
  duplicated on reload). Plugin now stores a non-owning UAS*; the UAS
  still owns the plugins. Verified: unload now removes UAS + all plugin
  nodes, reload does not duplicate them.
  2. Dynamically created plugin nodes no longer inherit process-global
  __node/__ns remap rules. A component container remaps itself with
  e.g. '-r __node:=<container>', which renamed every plugin node to the
  container name and caused topic type conflicts. Plugin nodes are now
  created with use_global_arguments(false), keeping their subnode name
  and the UAS namespace.
  Also move the Plugin constructors to plugin.cpp (UAS is an incomplete
  type at the point plugin.hpp is included) and update the composable test
  launch: fcu_url/gcs_url as launch arguments (no env-specific URL
  hardcoded) and the container selected by distro (component_container
  --executor-type events-cbg on Lyrical+, component_container_mt
  otherwise).
* mavros: runtime-selectable executor (MultiThreaded / EventsCBG)
  Introduce make_executor() factory honoring the MAVROS_EXECUTOR_TYPE env
  var (default 'mt', 'events'/'cbg' selects rclcpp's new Callback Group
  Events executor on Lyrical+). The UASExecutor wrapper and mavros_node
  container now build their executor via the factory, so the new
  EventsCBGExecutor can be tried without a rebuild.
  EventsCBGExecutor only exists since Lyrical (rclcpp >= 30.0.0); on older
  distros the events request warns and falls back to MultiThreadedExecutor.
  Also drop the now-dead UASExecutor::set_ids()/run() overrides (set_ids
  had no callers; run() is non-virtual in Lyrical's MultiThreadedExecutor).
* build: bump cmake_minimum_required to 3.10
  CMake (4.0+, as shipped on Lyrical/Rolling) emits a deprecation
  warning for cmake_minimum_required < 3.10:
  CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version
  of CMake.
  Raise the floor to 3.10 for all packages that were below it:
  - libmavconn, mavros, mavros_msgs, mavros_extras: 3.5 -> 3.10
  - test_mavros: 2.8.3 -> 3.10
  - mavros_examples: 3.8 -> 3.10
  3.10 is the lowest version that silences the warning while remaining
  compatible with all supported ROS 2 distros (Humble ships CMake 3.22).
* mavros: fix tf2 broadcaster ctor for Rolling, silence -Wmaybe-uninitialized
  tf2_ros (Iron+) deprecated/removed the NodeT pointer constructor for
  TransformBroadcaster and StaticTransformBroadcaster in favour of the
  rclcpp::node_interfaces::NodeInterfaces aggregate. On Rolling the
  NodeT overload is gone entirely, so mavros_uas.cpp:46-47 failed to
  compile:
  error: no matching function for call to
  'tf2_ros::TransformBroadcaster::TransformBroadcaster(mavros::uas::UAS*)'
  Use *this, which implicitly converts to the required NodeInterfaces,
  behind the existing USE_OLD_TF2_ROS guard so Humble (rclcpp < 17.0.0)
  keeps the NodeT pointer form.
  Also initialise locals read from parameters before get_parameter() to
  silence -Wmaybe-uninitialized on Lyrical/GCC 15:
  - tgt_system/tgt_component in mavros_uas.cpp
  - send_force in setpoint_accel.cpp
* Merge pull request #2242 <https://github.com/mavlink/mavros/issues/2242> from mavlink/followup-terrain-protocol
  extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
* common: modernize Python packaging to pyproject.toml for all packages
  - mavros: add pyproject.toml, simplify setup.py to shim, trim setup.cfg
  - mavros_examples: add pyproject.toml, simplify setup.py, trim setup.cfg,
  delete ruff.toml (merged into pyproject.toml)
  - mavros: ignore CNL100 flake8 rule (class def without blank line)
* common: reformat py by ruff
* extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
  Address review comments on merged PR #2137 <https://github.com/mavlink/mavros/issues/2137>:
  - Consolidate terrain Python files into terrain_server/ subpackage
  with single CLI entrypoint (node|preload|update|validate)
  - Use mavros.base.BaseNode for topic namespacing (mavros-py integration)
  - Replace zlib/hex blob with raw srtm_continent_map.bin resource file
  loaded via importlib.resources (no compression, auditable)
  - Switch TerrainData/TerrainRequest to float64 latitude/longitude
  matching TerrainReport/TerrainCheck (ROS convention)
  - Dedupe doxy blocks in terrain.cpp, add cmath for std::lround
  - Add proxy support (HTTP/HTTPS) and scheme-configurable srtm_data_url
  for Squid/nginx cache deployments
  - Fix concurrency bug: move tile downloads to background ThreadPoolExecutor
  so the 5Hz timer callback is never blocked
  - Add strict .hgt size validation after extraction
  - Add click-based CLI with preload/update/validate cache subcommands
  - Revert apm.launch to clean state, create apm_with_terrain.launch
  - Update AGENTS.md: always cd /ws before colcon, don't use --base-paths
  Co-authored-by: Zeke Sarosi <zeke.sarosi@gmail.com>
* Merge pull request #2137 <https://github.com/mavlink/mavros/issues/2137> from zekesarosi/ros2
  TERRAIN Protocol Integration
* Merge pull request #2105 <https://github.com/mavlink/mavros/issues/2105> from mavlink/refactor-router
  Refactor router
* router: break Endpoint<->Router ref cycle in test teardown
  router->endpoints holds each endpoint, and each endpoint->parent holds the
  Router back, forming a reference cycle. Combined with Mock::AllowLeak, the
  Router node (a DDS participant) was never destroyed between tests, so leaked
  participants accumulated and crashed FastDDS when colcon test ran packages in
  parallel (the default executor).
  Track created routers in the fixture and clear their endpoints before
  rclcpp::shutdown(), so each participant is destroyed while rclcpp is still
  running. Verified: staggered parallel runs 0/48 (was 15/48), full colcon test
  across all packages 0 failures over repeated rounds.
* router: cancel startup_delay_timer on destruction
  ~Router() cancelled reconnect_timer and stale_addrs_timer but not
  startup_delay_timer. The one-shot 10ms startup timer fires param_init_once()
  (via shared_from_this()); if the router was destroyed within 10ms of
  construction, the pending timer could fire on a dying node and crash during
  teardown. This made mavros-router-test flaky (SIGSEGV after tests passed).
  Cancel startup_delay_timer alongside the other timers. Verified: router test
  looped 200x with no failures (previously failed ~1/16).
* ci: enable coverage job for mavros
* mavros: add stale-address lifecycle test
* mavros: add router fallback and drop-path tests
* mavros: add skippable router stress test
* mavros: use shared io_context in router endpoints
* mavros: modernize router for C++20
* router: reduce critical section
  mavros: reduce router lock hold time
* move to standard
* Replace AUTOPILOT_CAPACITIES (deprecated) by REQUEST_MESSAGE
* mavros: fix cpplint code style alert
* fix(frame_tf): handle gimbal lock in quaternion_to_rpy, fix __123 test angles
  At pitch = ±π/2 the third-row elements m(2,1) and m(2,2) are both zero,
  making atan2(0, 0) undefined for roll and yaw. Add an explicit gimbal-lock
  branch: detect cos_pitch < 1e-9 and recover the one observable degree of
  freedom (yaw−roll at +π/2, yaw+roll at −π/2) while setting roll = 0.
  Also change the __123 test to use pitch=0.5 rad (≈28°) instead of 2.0 rad
  (≈114°). ZYX Euler angles are only unique for |pitch| < π/2; the old value
  was outside that domain and only passed by coincidence with eulerAngles.
  All 8 quaternion-utils tests pass with the local build.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* fix(frame_tf): replace eulerAngles(2,1,0) with atan2-based ZYX decomposition in quaternion_to_rpy
  Eigen::eulerAngles(2,1,0) clamps the primary (yaw) angle to [0, π].
  Any NED heading in (π, 2π) is silently remapped to a wrong value,
  causing vision_pose_estimate to report a frozen yaw of ~3.14 rad when
  the vehicle crosses the π boundary (MAVROS #444 <https://github.com/mavlink/mavros/issues/444>, #1472 <https://github.com/mavlink/mavros/issues/1472>).
  Replace with the standard ZYX rotation-matrix decomposition using atan2
  and asin, which recovers yaw in the full (-π, π] range. Roll and pitch
  coverage is unchanged: [-π, π] and [-π/2, π/2] respectively. The
  gimbal-lock singularity at pitch ≈ ±90° is an intrinsic ZYX limitation
  unrelated to this bug.
  Also add a regression test (quaternion_to_rpy__yaw_full_circle) that
  sweeps yaw through all integer degrees in [-179°, 180°] with fixed small
  roll/pitch and asserts exact round-trip recovery, and update the stale
  comment in quaternion_to_rpy__pm_pi to reflect the remaining limitation.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* global_position: fix velocity conversion to ENU
* mavros: ignore intentional cmd shadow lint
* fix uncrustify
* mavros: make UAS executor threads configurable
  - Add MAVROS_UAS_EXECUTOR_THREADS env var to control thread count
  - Log parse results (warnings for invalid values, info for overrides)
  - Enforce minimum of 2 threads when env var is set
* mavros: uncrustify plugin list validation
* mavros: validate plugin list patterns
* fix: use dedicated callback group for blocking services
* fixed the bug
* fix: std::future_error in command.cpp when the set_value() promise called twice
* style - apply ament_uncrustify from kilted
* Ensure map_point is init, early return if ECEF conversion fails and only update map_origin, ecef_origin is conversion ok
* Sys status: add mutex to M_VehicleInfo vehicles unordered map
* Stop the executor before plugin nodes and subscriptions begin tearing down
* check if thread joinable before joining
* mavros_uas change declaration order to ensure the destructor does not throw
* do not call parameters_missing_idx.front() if list is empty
* use shared_lock in read-only paths
* use shared_mutex instead of mutex
* add missing mutex lock
* Fix mavros_router segfault with mutex on remote_addrs
* rework
* imu: fix missing hPa to Pa conversion in HIGHRES_IMU handler
  abs_pressure and diff_pressure in HIGHRES_IMU messages are in hPa,
  but sensor_msgs/FluidPressure.fluid_pressure is in Pascals. MILLIBAR_TO_PASCAL  was already defined but not applied, resulting in pressure values 100 times too small.
  Also adjusted the handle_scaled_pressure to use MILLIBAR_TO_PASCAL for consistency instead of 100 magic number.
* plugins: re-generate xml
* docs: correct some more typos and spelling erorors
* docs: fix some spelling errors
* docs: trying to parse using libclang
* add atomic completion flag to ParamSetOpt
* Contributors: 8to, Alex Bennett, Beniamino Pozzan, Falah Naufal Zaki, Luka Filipović, Vladimir Ermakov, Your Name, Zeke Sarosi, apple, jonas, mitchellecm7, odraudE31, victor
```

## mavros_examples

```
* build: bump cmake_minimum_required to 3.10
  CMake (4.0+, as shipped on Lyrical/Rolling) emits a deprecation
  warning for cmake_minimum_required < 3.10:
  CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version
  of CMake.
  Raise the floor to 3.10 for all packages that were below it:
  - libmavconn, mavros, mavros_msgs, mavros_extras: 3.5 -> 3.10
  - test_mavros: 2.8.3 -> 3.10
  - mavros_examples: 3.8 -> 3.10
  3.10 is the lowest version that silences the warning while remaining
  compatible with all supported ROS 2 distros (Humble ships CMake 3.22).
* Merge pull request #2242 <https://github.com/mavlink/mavros/issues/2242> from mavlink/followup-terrain-protocol
  extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
* common: modernize Python packaging to pyproject.toml for all packages
  - mavros: add pyproject.toml, simplify setup.py to shim, trim setup.cfg
  - mavros_examples: add pyproject.toml, simplify setup.py, trim setup.cfg,
  delete ruff.toml (merged into pyproject.toml)
  - mavros: ignore CNL100 flake8 rule (class def without blank line)
* Contributors: Vladimir Ermakov
```

## mavros_extras

```
* Merge pull request #2259 <https://github.com/mavlink/mavros/issues/2259> from mavlink/docs-refresh
  docs: refresh, refactor extractor
* cog: re-generate all
* docs: refresh subpackage READMEs
  - mavros: point the API docs link at readthedocs/plugin reference instead of
  the dead wiki.ros.org page; fix ROS1 roslaunch examples to ros2 launch; note
  that up-to-date install instructions live in the readthedocs guide.
  - mavros_extras: link to the full plugin reference.
  - libmavconn: link to the docs and API reference.
  - mavros_msgs: add the missing README (message/service overview + API links).
  - test_mavros: mark the ROS1-era SITL hand-tests as historical.
* docs: remove redundant topic repetitions in plugin docs
  - sim_state: drop the topic list from the class brief; the generated
  Publishers section already lists each topic with a description.
  - Separate section-marker // comments (e.g. "// publishers") from the
  //! entity description with a blank line, so the extractor no longer
  concatenates them into verbose descriptions like "publishers Publish
  DEBUG messages...".
  - Regenerate docs.
* Merge pull request #2258 <https://github.com/mavlink/mavros/issues/2258> from mavlink/plugin-tests
  Plugin tests
* mavros: disable intra-process for latched publishers
  Plugin nodes enable intra-process comms, but rclcpp (e.g. humble) rejects
  creating a latched (transient_local) publisher or subscription on an
  intra-process node: "intraprocess communication allowed only with volatile
  durability". This made the waypoint/geofence/rallypoint/global_position/
  home_position/sys_status plugins (which publish latched state) fail to start
  on humble, and the mission plugin test crash in CI.
  Add NonIntraProcessPublisherOptions()/NonIntraProcessSubscriptionOptions()
  helpers and pass them to the transient_local publishers and subscriptions, so
  those entities opt out of intra-process delivery while volatile topics keep
  the zero-copy path.
* docs: add ROS API descriptions to all plugins and regenerate docs
  Add one-line //! descriptions for every exposed publisher, subscriber,
  service, client and parameter across all mavros and mavros_extras plugins,
  so the generated per-plugin docs describe what each ROS entity does.
  Regenerate the plugin docs and index, and add a readthedocs Documentation
  badge to the README.
* docs: add mavlink subprotocol references to plugin docs
  Add a reference to the relevant MAVLink microservice (subprotocol) page in
  the doxygen description of each plugin that maps to one. The references flow
  through the existing doc extractor/template pipeline.
* build: bump cmake_minimum_required to 3.10
  CMake (4.0+, as shipped on Lyrical/Rolling) emits a deprecation
  warning for cmake_minimum_required < 3.10:
  CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version
  of CMake.
  Raise the floor to 3.10 for all packages that were below it:
  - libmavconn, mavros, mavros_msgs, mavros_extras: 3.5 -> 3.10
  - test_mavros: 2.8.3 -> 3.10
  - mavros_examples: 3.8 -> 3.10
  3.10 is the lowest version that silences the warning while remaining
  compatible with all supported ROS 2 distros (Humble ships CMake 3.22).
* Merge pull request #2242 <https://github.com/mavlink/mavros/issues/2242> from mavlink/followup-terrain-protocol
  extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
* extras: fix importlib.resources.files() on Python 3.10 (humble)
  files(__name__) fails on Python 3.10 because srtm_continent_map is a
  module, not a package. Python 3.12+ relaxed files() to also accept
  modules, but humble (3.10) still requires a package.
  Use __package__ (the parent 'terrain_server' package) instead.
* extras: modernize Python packaging to pyproject.toml
  - Add pyproject.toml with project metadata, entry points, and ruff config
  - Simplify setup.py to minimal shim (for legacy/ament compatibility)
  - Trim setup.cfg to only ament-specific sections (entry_points, flake8, paths)
  - Delete ruff.toml (merged into pyproject.toml [tool.ruff])
  - Works on Humble (setuptools>=61) through Lyrical
* extras: fix CI — add python3-click dep, use find_packages for subpackage
  - Add python3-click exec_depend to package.xml
  - Use find_packages() in setup.py so terrain_server/ subpackage gets
  installed (packages=[name] only installs the top-level package)
* common: reformat py by ruff
* extras: terrain_server: retry downloads with backoff, fix --ros-args passthrough
  - Add exponential backoff retry (5 attempts, 1/2/4/8s) for transient
  network errors (TimeoutError, URLError, OSError)
  - Increase download timeout from 60s to 120s
  - Fix click CLI intercepting --ros-args: bypass click when no known
  subcommand is given, pass args directly to rclpy.init
  - Use Path() instead of os.path.join for default cache path
  - Move time import to module level
* extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
  Address review comments on merged PR #2137 <https://github.com/mavlink/mavros/issues/2137>:
  - Consolidate terrain Python files into terrain_server/ subpackage
  with single CLI entrypoint (node|preload|update|validate)
  - Use mavros.base.BaseNode for topic namespacing (mavros-py integration)
  - Replace zlib/hex blob with raw srtm_continent_map.bin resource file
  loaded via importlib.resources (no compression, auditable)
  - Switch TerrainData/TerrainRequest to float64 latitude/longitude
  matching TerrainReport/TerrainCheck (ROS convention)
  - Dedupe doxy blocks in terrain.cpp, add cmath for std::lround
  - Add proxy support (HTTP/HTTPS) and scheme-configurable srtm_data_url
  for Squid/nginx cache deployments
  - Fix concurrency bug: move tile downloads to background ThreadPoolExecutor
  so the 5Hz timer callback is never blocked
  - Add strict .hgt size validation after extraction
  - Add click-based CLI with preload/update/validate cache subcommands
  - Revert apm.launch to clean state, create apm_with_terrain.launch
  - Update AGENTS.md: always cd /ws before colcon, don't use --base-paths
  Co-authored-by: Zeke Sarosi <zeke.sarosi@gmail.com>
* Merge pull request #2137 <https://github.com/mavlink/mavros/issues/2137> from zekesarosi/ros2
  TERRAIN Protocol Integration
* mavros_extras: Fix dangling pointers and uninitialized memory in Eigen expressions
  Swapped auto for explicit Eigen::VectorX types in hil.cpp
  and mount_control.cpp to prevent expression templates from holding
  dangling pointers to temporary objects.
* Update fake_gps.cpp to use libraries in tf2_eigen
  Without this plugins will fail to load with an undefined symbol:
  Something like:
  ```
  load exception: Failed to load library /tmp/mavros/install/mavros_extras/lib/libmavros_extras_plugins.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library dlopen error: /tmp/mavros/install/mavros_extras/lib/libmavros_extras_plugins.so: undefined symbol: _ZN3tf27fromMsgIN13geometry_msgs3msg10Transform_ISaIvEEEN5Eigen9TransformIdLi3ELi2ELi0EEEEEvRKT_RT0\_
  ```
  I am using ROS2 Jazzy on Ubuntu 24.04
* when lookup_static_transform fails,  drop that odometry sample instead of calling .linear(), .inverse()
* more formatting
* formatting changes
* samgrep fixes
* added tests, removed deps. incorportated suggestions
* fix: Out-of-Bounds Write and Divide-by-Zero Bugs Found in...
  Fixes #2115 <https://github.com/mavlink/mavros/issues/2115>
* minor bug fix
* rework
* terrain server
* plugins: re-generate xml
* docs: correct some more typos and spelling erorors
* docs: fix some spelling errors
* Contributors: Tomas Baca, Vladimir Ermakov, Zeke Sarosi, benjaminholdennearearth, jonas, roberthallers
```

## mavros_msgs

```
* Merge pull request #2259 <https://github.com/mavlink/mavros/issues/2259> from mavlink/docs-refresh
  docs: refresh, refactor extractor
* docs: refresh subpackage READMEs
  - mavros: point the API docs link at readthedocs/plugin reference instead of
  the dead wiki.ros.org page; fix ROS1 roslaunch examples to ros2 launch; note
  that up-to-date install instructions live in the readthedocs guide.
  - mavros_extras: link to the full plugin reference.
  - libmavconn: link to the docs and API reference.
  - mavros_msgs: add the missing README (message/service overview + API links).
  - test_mavros: mark the ROS1-era SITL hand-tests as historical.
* build: bump cmake_minimum_required to 3.10
  CMake (4.0+, as shipped on Lyrical/Rolling) emits a deprecation
  warning for cmake_minimum_required < 3.10:
  CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version
  of CMake.
  Raise the floor to 3.10 for all packages that were below it:
  - libmavconn, mavros, mavros_msgs, mavros_extras: 3.5 -> 3.10
  - test_mavros: 2.8.3 -> 3.10
  - mavros_examples: 3.8 -> 3.10
  3.10 is the lowest version that silences the warning while remaining
  compatible with all supported ROS 2 distros (Humble ships CMake 3.22).
* Merge pull request #2242 <https://github.com/mavlink/mavros/issues/2242> from mavlink/followup-terrain-protocol
  extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
* extras: polish terrain protocol integration (PR #2137 <https://github.com/mavlink/mavros/issues/2137> followup)
  Address review comments on merged PR #2137 <https://github.com/mavlink/mavros/issues/2137>:
  - Consolidate terrain Python files into terrain_server/ subpackage
  with single CLI entrypoint (node|preload|update|validate)
  - Use mavros.base.BaseNode for topic namespacing (mavros-py integration)
  - Replace zlib/hex blob with raw srtm_continent_map.bin resource file
  loaded via importlib.resources (no compression, auditable)
  - Switch TerrainData/TerrainRequest to float64 latitude/longitude
  matching TerrainReport/TerrainCheck (ROS convention)
  - Dedupe doxy blocks in terrain.cpp, add cmath for std::lround
  - Add proxy support (HTTP/HTTPS) and scheme-configurable srtm_data_url
  for Squid/nginx cache deployments
  - Fix concurrency bug: move tile downloads to background ThreadPoolExecutor
  so the 5Hz timer callback is never blocked
  - Add strict .hgt size validation after extraction
  - Add click-based CLI with preload/update/validate cache subcommands
  - Revert apm.launch to clean state, create apm_with_terrain.launch
  - Update AGENTS.md: always cd /ws before colcon, don't use --base-paths
  Co-authored-by: Zeke Sarosi <zeke.sarosi@gmail.com>
* Merge pull request #2137 <https://github.com/mavlink/mavros/issues/2137> from zekesarosi/ros2
  TERRAIN Protocol Integration
* added tests, removed deps. incorportated suggestions
* rework
* docs: correct some more typos and spelling erorors
* docs: fix some spelling errors
* Contributors: Vladimir Ermakov, Zeke Sarosi
```
