### PR TITLE
yasmin: 6.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -11302,7 +11302,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 6.1.0-2
+      version: 6.1.1-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `6.1.1-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.1.0-2`

## yasmin

- No changes

## yasmin_cli

- No changes

## yasmin_demos

- No changes

## yasmin_editor

- No changes

## yasmin_factory

- No changes

## yasmin_msgs

```
* yasmin_msgs: Depend on action_msgs (#127 <https://github.com/uleroboticsgroup/yasmin/issues/127>)
  Without this dependency, when the package is build separately, the
  build fails with the following error:
  CMake Error at /nix/store/x11khyi2rivpyy70xxvkm319v5nzwq75-ros-humble-rosidl-cmake-3.1.9-r1/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:147 (message):
  Unable to generate action interface for 'action/RunStateMachine.action'.
  In order to generate action interfaces you must add a depend tag for
  'action_msgs' in your package.xml.
  Call Stack (most recent call first):
  CMakeLists.txt:8 (rosidl_generate_interfaces)
* Contributors: Michal Sojka
```

## yasmin_pcl

- No changes

## yasmin_plugins_manager

- No changes

## yasmin_ros

- No changes

## yasmin_viewer

```
* Allow remote connections to yasmin_viewer (#129 <https://github.com/uleroboticsgroup/yasmin/issues/129>)
* Minimize boost dependencies as only headers are used during build (#128 <https://github.com/uleroboticsgroup/yasmin/issues/128>)
* Contributors: Ferry Schoenmakers
```
