### PR TITLE
unbag: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10697,6 +10697,11 @@ repositories:
       version: main
     status: maintained
   unbag:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/unbag-release.git
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/ros2_unbag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `unbag` to `1.3.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/ros2_unbag.git
- release repository: https://github.com/ros2-gbp/unbag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

CHANGELOG
---------
### unbag (1.3.0-1)

- Autogenerated, no changelog for this version found in CHANGELOG.rst.