### PR TITLE
Add metriplane to Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5826,6 +5826,11 @@ repositories:
       url: https://github.com/ros-event-camera/metavision_driver.git
       version: release
     status: developed
+  metriplane:
+    doc:
+      type: git
+      url: https://github.com/Miko997/metriplane.git
+      version: main
   micro_ros_diagnostics:
     doc:
       type: git


### PR DESCRIPTION
# Please add Metriplane to be indexed in the ROS 2 Jazzy rosdistro

Metriplane is an open-source Python system for workcell state observation, evidence generation, incident analysis, and reproducible evaluation.

The repository contains the `metriplane_ros` ROS 2 bridge package. The bridge connects to a running Metriplane WebSocket stream and republishes Metriplane frames, alerts, and incidents as `std_msgs/String` JSON topics.

The ROS 2 bridge has been runtime-smoke-tested on ROS 2 Jazzy, including:

- `colcon build`
- `ros2 run`
- `ros2 launch`
- publication of `/metriplane/frame_state`
- publication of `/metriplane/alerts`
- publication of `/metriplane/incidents`
- `ros2 topic echo`
- recording the published topics with `ros2 bag record`

No ROS bag replay functionality is claimed by this submission.

## ROS distribution

Jazzy

## Source

https://github.com/Miko997/metriplane

## ROS package

`integrations/ros2/metriplane_ros`

## Package name

`metriplane_ros`

## License

MIT

## Checks

- [x] All packages have a declared license in the `package.xml`
- [x] This repository has a LICENSE file
- [x] This package has been built and runtime-smoke-tested on ROS 2 Jazzy