### PR TITLE
Update RHEL 8 dependencies from null to qt5 packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6873,7 +6873,7 @@ libqtcore:
     '15.2': null
   rhel:
     '*': [qt6-qtbase]
-    '8': null
+    '8': [qt5-qtbase]
     '9': [qt5-qtbase]
   slackware: [qt6]
   ubuntu:
@@ -6892,7 +6892,7 @@ libqtgui:
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase-gui]
-    '8': null
+    '8': [qt5-qtbase-gui]
     '9': [qt5-qtbase-gui]
   slackware: [qt6]
   ubuntu:
@@ -6917,7 +6917,7 @@ libqtopengl:
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
-    '8': null
+    '8': [qt5-qtbase]
     '9': [qt5-qtbase]
   ubuntu:
     '*': [libqt6opengl6]
@@ -6934,7 +6934,7 @@ libqtsvg:
   openembedded: [qtsvg@meta-qt6]
   rhel:
     '*': [qt6-qtsvg]
-    '8': null
+    '8': [qt5-qtsvg]
     '9': [qt5-qtsvg]
   ubuntu:
     '*': [libqt6svg6]
@@ -6957,7 +6957,7 @@ libqtwidgets:
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
-    '8': null
+    '8': [qt5-qtbase]
     '9': [qt5-qtbase]
   ubuntu:
     '*': [libqt6widgets6]
@@ -9545,7 +9545,7 @@ qt-base-dev:
     '15.2': null
   rhel:
     '*': [qt6-qtbase-devel]
-    '8': null
+    '8': [qt5-qtbase-devel]
     '9': [qt5-qtbase-devel]
   slackware: [qt6]
   ubuntu:
@@ -9563,7 +9563,7 @@ qt-svg-dev:
   openembedded: [qtsvg@meta-qt6]
   rhel:
     '*': [qt6-qtsvg-devel]
-    '8': null
+    '8': [qt5-qtsvg-devel]
     '9': [qt5-qtsvg-devel]
   ubuntu:
     '*': [qt6-svg-dev]


### PR DESCRIPTION
This updates the Qt packages that map to either Qt5 or Qt6 for RHEL 8 so that generic references can be made to these dependencies for repos that are building for both Qt5 and Qt6.