### PR TITLE
ros2_control: 6.9.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8178,7 +8178,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.8.0-1
+      version: 6.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.9.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.8.0-1`

## controller_interface

```
* Add RangeSensor unit coverage (#3522 <https://github.com/ros-controls/ros2_control/issues/3522>)
* Document realtime-safe methods (#3392 <https://github.com/ros-controls/ros2_control/issues/3392>)
* Contributors: Dennis Lanov, Shivam Maurya
```

## controller_manager

```
* Make configure_controller lifecycle transition strict (no multi-hop) (#3196 <https://github.com/ros-controls/ros2_control/issues/3196>)
* Refactor launch test to use launch substitutions instead of os (#3142 <https://github.com/ros-controls/ros2_control/issues/3142>)
* doc: reorder ros2_control TOC (#3478 <https://github.com/ros-controls/ros2_control/issues/3478>)
* Add tests for launch_utils of controller manager (#2768 <https://github.com/ros-controls/ros2_control/issues/2768>)
* Create spawner logger before lock-result is logged (#3462 <https://github.com/ros-controls/ros2_control/issues/3462>)
* remove unused code in hardware components diagnostics (#3488 <https://github.com/ros-controls/ros2_control/issues/3488>)
* Guard controller update rate against modulo-by-zero UB (#3454 <https://github.com/ros-controls/ros2_control/issues/3454>)
* Make sleep in ros2_control node optional (#3213 <https://github.com/ros-controls/ros2_control/issues/3213>)
* Contributors: Advitya Singh, Aniruddh Yelluri, Christian Rauch, FAN YUCHEN, Felix Exner, Rishitha, Vedh, robkwan
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Avoid Windows TRUE/FALSE macro collisions in hardware_interface (#3486 <https://github.com/ros-controls/ros2_control/issues/3486>)
* doc: reorder ros2_control TOC (#3478 <https://github.com/ros-controls/ros2_control/issues/3478>)
* Remove deprecated HardwareInfo::thread_priority member (#3484 <https://github.com/ros-controls/ros2_control/issues/3484>)
* Use stream parsing for hardware_interface floats on Apple (#3485 <https://github.com/ros-controls/ros2_control/issues/3485>)
* Contributors: Aniruddh Yelluri, Ismet Vahidezade, Tobias Fischer
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Fix joint limits namespace wording (#3445 <https://github.com/ros-controls/ros2_control/issues/3445>)
* Contributors: Mohammad Hossein Fakouri
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Make configure_controller lifecycle transition strict (no multi-hop) (#3196 <https://github.com/ros-controls/ros2_control/issues/3196>)
* doc: reorder ros2_control TOC (#3478 <https://github.com/ros-controls/ros2_control/issues/3478>)
* Contributors: Aniruddh Yelluri, Vedh
```

## rqt_controller_manager

```
* rqt_cm: Robustify test and fix shutdown races (#3396 <https://github.com/ros-controls/ros2_control/issues/3396>)
* Contributors: Christoph Fröhlich
```

## transmission_interface

- No changes
