### PR TITLE
ros2_control: 4.47.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9798,7 +9798,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.46.0-1
+      version: 4.47.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.47.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.46.0-1`

## controller_interface

```
* Add RangeSensor unit coverage (#3522 <https://github.com/ros-controls/ros2_control/issues/3522>) (#3528 <https://github.com/ros-controls/ros2_control/issues/3528>)
* Document realtime-safe methods (#3392 <https://github.com/ros-controls/ros2_control/issues/3392>) (#3507 <https://github.com/ros-controls/ros2_control/issues/3507>)
* Fix merge conflict in docstring (#3441 <https://github.com/ros-controls/ros2_control/issues/3441>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## controller_manager

```
* Refactor launch test to use launch substitutions instead of os (#3142 <https://github.com/ros-controls/ros2_control/issues/3142>) (#3524 <https://github.com/ros-controls/ros2_control/issues/3524>)
* doc: reorder ros2_control TOC (backport #3478 <https://github.com/ros-controls/ros2_control/issues/3478>) (#3516 <https://github.com/ros-controls/ros2_control/issues/3516>)
* Add tests for launch_utils of controller manager (#2768 <https://github.com/ros-controls/ros2_control/issues/2768>) (#3510 <https://github.com/ros-controls/ros2_control/issues/3510>)
* Create spawner logger before lock-result is logged (backport #3462 <https://github.com/ros-controls/ros2_control/issues/3462>) (#3505 <https://github.com/ros-controls/ros2_control/issues/3505>)
* Controller Manager recovery from invalid URDF errors (backport #2775 <https://github.com/ros-controls/ros2_control/issues/2775>) (#3394 <https://github.com/ros-controls/ros2_control/issues/3394>)
* Add cmath for windows build (#3496 <https://github.com/ros-controls/ros2_control/issues/3496>)
* Guard controller update rate against modulo-by-zero UB (#3454 <https://github.com/ros-controls/ros2_control/issues/3454>) (#3476 <https://github.com/ros-controls/ros2_control/issues/3476>)
* Make sleep in ros2_control node optional (backport #3213 <https://github.com/ros-controls/ros2_control/issues/3213>) (#3452 <https://github.com/ros-controls/ros2_control/issues/3452>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Avoid Windows TRUE/FALSE macro collisions in hardware_interface (#3486 <https://github.com/ros-controls/ros2_control/issues/3486>) (#3526 <https://github.com/ros-controls/ros2_control/issues/3526>)
* doc: reorder ros2_control TOC (backport #3478 <https://github.com/ros-controls/ros2_control/issues/3478>) (#3516 <https://github.com/ros-controls/ros2_control/issues/3516>)
* Controller Manager recovery from invalid URDF errors (backport #2775 <https://github.com/ros-controls/ros2_control/issues/2775>) (#3394 <https://github.com/ros-controls/ros2_control/issues/3394>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Fix joint limits namespace wording (#3445 <https://github.com/ros-controls/ros2_control/issues/3445>) (#3447 <https://github.com/ros-controls/ros2_control/issues/3447>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Controller Manager recovery from invalid URDF errors (backport #2775 <https://github.com/ros-controls/ros2_control/issues/2775>) (#3394 <https://github.com/ros-controls/ros2_control/issues/3394>)
* Contributors: mergify[bot]
```

## ros2controlcli

```
* doc: reorder ros2_control TOC (backport #3478 <https://github.com/ros-controls/ros2_control/issues/3478>) (#3516 <https://github.com/ros-controls/ros2_control/issues/3516>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* rqt_cm: Robustify test and fix shutdown races (backport #3396 <https://github.com/ros-controls/ros2_control/issues/3396>) (#3464 <https://github.com/ros-controls/ros2_control/issues/3464>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
