### PR TITLE
ros2_control: 5.17.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7993,7 +7993,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.16.0-1
+      version: 5.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.17.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.16.0-1`

## controller_interface

```
* Add RangeSensor unit coverage (#3522 <https://github.com/ros-controls/ros2_control/issues/3522>) (#3529 <https://github.com/ros-controls/ros2_control/issues/3529>)
* Document realtime-safe methods (#3392 <https://github.com/ros-controls/ros2_control/issues/3392>) (#3508 <https://github.com/ros-controls/ros2_control/issues/3508>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Refactor launch test to use launch substitutions instead of os (#3142 <https://github.com/ros-controls/ros2_control/issues/3142>) (#3525 <https://github.com/ros-controls/ros2_control/issues/3525>)
* doc: reorder ros2_control TOC (backport #3478 <https://github.com/ros-controls/ros2_control/issues/3478>) (#3517 <https://github.com/ros-controls/ros2_control/issues/3517>)
* Add tests for launch_utils of controller manager (#2768 <https://github.com/ros-controls/ros2_control/issues/2768>) (#3511 <https://github.com/ros-controls/ros2_control/issues/3511>)
* Create spawner logger before lock-result is logged (#3462 <https://github.com/ros-controls/ros2_control/issues/3462>) (#3506 <https://github.com/ros-controls/ros2_control/issues/3506>)
* Guard controller update rate against modulo-by-zero UB (#3454 <https://github.com/ros-controls/ros2_control/issues/3454>) (#3477 <https://github.com/ros-controls/ros2_control/issues/3477>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Avoid Windows TRUE/FALSE macro collisions in hardware_interface (#3486 <https://github.com/ros-controls/ros2_control/issues/3486>) (#3527 <https://github.com/ros-controls/ros2_control/issues/3527>)
* doc: reorder ros2_control TOC (backport #3478 <https://github.com/ros-controls/ros2_control/issues/3478>) (#3517 <https://github.com/ros-controls/ros2_control/issues/3517>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* doc: reorder ros2_control TOC (backport #3478 <https://github.com/ros-controls/ros2_control/issues/3478>) (#3517 <https://github.com/ros-controls/ros2_control/issues/3517>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* rqt_cm: Robustify test and fix shutdown races (backport #3396 <https://github.com/ros-controls/ros2_control/issues/3396>) (#3465 <https://github.com/ros-controls/ros2_control/issues/3465>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
