### PR TITLE
osqp_vendor: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5823,7 +5823,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osqp_vendor-release.git
-      version: 0.2.0-4
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/moveit/osqp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/moveit/osqp_vendor.git
- release repository: https://github.com/ros2-gbp/osqp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.0-4`

## osqp_vendor

```
* Update OSQP version to v1.0.0 (#1 <https://github.com/moveit/osqp_vendor/issues/1>)
* Update .github tests (#20 <https://github.com/tier4/osqp_vendor/issues/20>)
* Update OSQP -drop ros1 (#22 <https://github.com/tier4/osqp_vendor/issues/22>)
* Contributors: Sebastian Castro, mosfet80
```
