### PR TITLE
Remove 'nanoflann' from distribution lists

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6805,21 +6805,6 @@ repositories:
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main
     status: developed
-  nanoflann:
-    doc:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/nanoflann-release.git
-      version: 1.12.0-1
-    source:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    status: developed
   nao_button_sim:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6657,21 +6657,6 @@ repositories:
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main
     status: developed
-  nanoflann:
-    doc:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/nanoflann-release.git
-      version: 1.11.0-1
-    source:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    status: developed
   nao_button_sim:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5317,21 +5317,6 @@ repositories:
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main
     status: developed
-  nanoflann:
-    doc:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/nanoflann-release.git
-      version: 1.11.0-1
-    source:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    status: developed
   nao_button_sim:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5461,21 +5461,6 @@ repositories:
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main
     status: developed
-  nanoflann:
-    doc:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    release:
-      tags:
-        release: release/lyrical/{package}/{version}
-      url: https://github.com/ros2-gbp/nanoflann-release.git
-      version: 1.11.0-1
-    source:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    status: developed
   nao_button_sim:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5245,21 +5245,6 @@ repositories:
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main
     status: developed
-  nanoflann:
-    doc:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/nanoflann-release.git
-      version: 1.11.0-1
-    source:
-      type: git
-      url: https://github.com/jlblancoc/nanoflann.git
-      version: master
-    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
Porting to nanoflann_vendor.

Rationale and discussion: https://github.com/ros/rosdistro/issues/53134
