### PR TITLE
warehouse_ros: 2.0.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -13717,7 +13717,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros-release.git
-      version: 2.0.7-1
+      version: 2.0.8-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.8-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros2-gbp/warehouse_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.7-1`

## warehouse_ros

```
* Merge pull request #111 <https://github.com/moveit/warehouse_ros/issues/111> from moveit/nbbrooks/ci-matrix-distro-coverage
  ci: cover kilted and lyrical, drop the impossible rolling-main job
* ci: cover kilted and lyrical, and drop the impossible rolling-main job
  Rolling's main apt repo has no Resolute packages, so rolling+main cannot
  install and has been failing since at least 2026-07-13. Replace it with
  kilted and lyrical, matching moveit_visual_tools`#157 <https://github.com/moveit/warehouse_ros/issues/157>`_ and
  rviz_visual_tools`#301 <https://github.com/moveit/warehouse_ros/issues/301>`_.
  Co-Authored-By: Claude Opus 5 <mailto:noreply@anthropic.com>
* Merge pull request #110 <https://github.com/moveit/warehouse_ros/issues/110> from moveit/nbbrooks/fix-transform-listener-rolling
  Fix Rolling build: TransformListener node-pointer ctor removed in tf2_ros 0.46.2
* Let TransformListener own its node in LiveTransformSource
  Use the buffer-only tf2_ros::TransformListener constructor instead of
  passing a node, and drop the now-unused node_ member.
  Co-Authored-By: Claude Opus 5 <mailto:noreply@anthropic.com>
* Contributors: Nathan Brooks
```
