### PR TITLE
geometric_shapes: 2.3.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2688,7 +2688,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.3.3-1
+      version: 2.3.4-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.3.4-1`:

- upstream repository: https://github.com/moveit/geometric_shapes.git
- release repository: https://github.com/ros2-gbp/geometric_shapes-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.3.3-1`

## geometric_shapes

```
* Remove octomap dependency (#269 <https://github.com/ros-planning/geometric_shapes/issues/269>)
* Bump minimum cmake version (#265 <https://github.com/ros-planning/geometric_shapes/issues/265>)
* Fix compiler warnings
* Contributors: Felix Exner, Nathan Brooks, Robert Haschke, mosfet80
```
