### PR TITLE
rosidl_rust: 0.5.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8758,7 +8758,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_rust-release.git
-      version: 0.4.12-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros2-rust/rosidl_rust.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_rust` to `0.5.0-1`:

- upstream repository: https://github.com/ros2-rust/rosidl_rust.git
- release repository: https://github.com/ros2-gbp/rosidl_rust-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.12-1`

## rosidl_generator_rs

```
* fix(generator): do not register generated crates in the rust_packages index
* fix(generator): make Cargo.toml dependencies deterministic (#28)
* fix(generator): allow IDL files outside standard folders
* perf(generator): use memcpy paths for primitive sequence conversion (#26)
* Contributors: Esteve Fernandez, Mathieu David
```
