### PR TITLE
Resolute: add all PCL keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5716,6 +5716,7 @@ libpcl-all:
     focal: [libpcl-apps1.10, libpcl-common1.10, libpcl-features1.10, libpcl-filters1.10, libpcl-io1.10, libpcl-kdtree1.10, libpcl-keypoints1.10, libpcl-ml1.10, libpcl-octree1.10, libpcl-outofcore1.10, libpcl-people1.10, libpcl-recognition1.10, libpcl-registration1.10, libpcl-sample-consensus1.10, libpcl-search1.10, libpcl-segmentation1.10, libpcl-stereo1.10, libpcl-surface1.10, libpcl-tracking1.10, libpcl-visualization1.10]
     jammy: [libpcl-apps1.12, libpcl-common1.12, libpcl-features1.12, libpcl-filters1.12, libpcl-io1.12, libpcl-kdtree1.12, libpcl-keypoints1.12, libpcl-ml1.12, libpcl-octree1.12, libpcl-outofcore1.12, libpcl-people1.12, libpcl-recognition1.12, libpcl-registration1.12, libpcl-sample-consensus1.12, libpcl-search1.12, libpcl-segmentation1.12, libpcl-stereo1.12, libpcl-surface1.12, libpcl-tracking1.12, libpcl-visualization1.12]
     noble: [libpcl-apps1.14, libpcl-common1.14, libpcl-features1.14, libpcl-filters1.14, libpcl-io1.14, libpcl-kdtree1.14, libpcl-keypoints1.14, libpcl-ml1.14, libpcl-octree1.14, libpcl-outofcore1.14, libpcl-people1.14, libpcl-recognition1.14, libpcl-registration1.14, libpcl-sample-consensus1.14, libpcl-search1.14, libpcl-segmentation1.14, libpcl-stereo1.14, libpcl-surface1.14, libpcl-tracking1.14, libpcl-visualization1.14]
+    resolute: [libpcl-apps1.15, libpcl-common1.15, libpcl-features1.15, libpcl-filters1.15, libpcl-io1.15, libpcl-kdtree1.15, libpcl-keypoints1.15, libpcl-ml1.15, libpcl-octree1.15, libpcl-outofcore1.15, libpcl-people1.15, libpcl-recognition1.15, libpcl-registration1.15, libpcl-sample-consensus1.15, libpcl-search1.15, libpcl-segmentation1.15, libpcl-stereo1.15, libpcl-surface1.15, libpcl-tracking1.15, libpcl-visualization1.15]
 libpcl-all-dev:
   debian: [libpcl-dev]
   fedora: [pcl-devel]
@@ -5746,6 +5747,7 @@ libpcl-apps:
     focal: [libpcl-apps1.10]
     jammy: [libpcl-apps1.12]
     noble: [libpcl-apps1.14]
+    resolute: [libpcl-apps1.15]
 libpcl-common:
   alpine: [pcl-libs]
   debian:
@@ -5848,6 +5850,7 @@ libpcl-kdtree:
     focal: [libpcl-kdtree1.10]
     jammy: [libpcl-kdtree1.12]
     noble: [libpcl-kdtree1.14]
+    resolute: [libpcl-kdtree1.15]
 libpcl-keypoints:
   alpine: [pcl-libs]
   debian:
@@ -5866,6 +5869,7 @@ libpcl-keypoints:
     focal: [libpcl-keypoints1.10]
     jammy: [libpcl-keypoints1.12]
     noble: [libpcl-keypoints1.14]
+    resolute: [libpcl-keypoints1.15]
 libpcl-ml:
   alpine: [pcl-libs]
   debian:
@@ -5884,6 +5888,7 @@ libpcl-ml:
     focal: [libpcl-ml1.10]
     jammy: [libpcl-ml1.12]
     noble: [libpcl-ml1.14]
+    resolute: [libpcl-ml1.15]
 libpcl-octree:
   alpine: [pcl-libs]
   debian:
@@ -5902,6 +5907,7 @@ libpcl-octree:
     focal: [libpcl-octree1.10]
     jammy: [libpcl-octree1.12]
     noble: [libpcl-octree1.14]
+    resolute: [libpcl-octree1.15]
 libpcl-outofcore:
   alpine: [pcl-libs]
   debian:
@@ -5920,6 +5926,7 @@ libpcl-outofcore:
     focal: [libpcl-outofcore1.10]
     jammy: [libpcl-outofcore1.12]
     noble: [libpcl-outofcore1.14]
+    resolute: [libpcl-outofcore1.15]
 libpcl-people:
   alpine: [pcl-libs]
   debian:
@@ -5938,6 +5945,7 @@ libpcl-people:
     focal: [libpcl-people1.10]
     jammy: [libpcl-people1.12]
     noble: [libpcl-people1.14]
+    resolute: [libpcl-people1.15]
 libpcl-recognition:
   alpine: [pcl-libs]
   debian:
@@ -5956,6 +5964,7 @@ libpcl-recognition:
     focal: [libpcl-recognition1.10]
     jammy: [libpcl-recognition1.12]
     noble: [libpcl-recognition1.14]
+    resolute: [libpcl-recognition1.15]
 libpcl-registration:
   alpine: [pcl-libs]
   debian:
@@ -5974,6 +5983,7 @@ libpcl-registration:
     focal: [libpcl-registration1.10]
     jammy: [libpcl-registration1.12]
     noble: [libpcl-registration1.14]
+    resolute: [libpcl-registration1.15]
 libpcl-sample-consensus:
   alpine: [pcl-libs]
   debian:
@@ -5992,6 +6002,7 @@ libpcl-sample-consensus:
     focal: [libpcl-sample-consensus1.10]
     jammy: [libpcl-sample-consensus1.12]
     noble: [libpcl-sample-consensus1.14]
+    resolute: [libpcl-sample-consensus1.15]
 libpcl-search:
   alpine: [pcl-libs]
   debian:
@@ -6010,6 +6021,7 @@ libpcl-search:
     focal: [libpcl-search1.10]
     jammy: [libpcl-search1.12]
     noble: [libpcl-search1.14]
+    resolute: [libpcl-search1.15]
 libpcl-segmentation:
   alpine: [pcl-libs]
   debian:
@@ -6049,6 +6061,7 @@ libpcl-stereo:
     focal: [libpcl-stereo1.10]
     jammy: [libpcl-stereo1.12]
     noble: [libpcl-stereo1.14]
+    resolute: [libpcl-stereo1.15]
 libpcl-surface:
   alpine: [pcl-libs]
   debian:
@@ -6088,6 +6101,7 @@ libpcl-tracking:
     focal: [libpcl-tracking1.10]
     jammy: [libpcl-tracking1.12]
     noble: [libpcl-tracking1.14]
+    resolute: [libpcl-tracking1.15]
 libpcl-visualization:
   alpine: [pcl-libs]
   debian:
@@ -6106,6 +6120,7 @@ libpcl-visualization:
     focal: [libpcl-visualization1.10]
     jammy: [libpcl-visualization1.12]
     noble: [libpcl-visualization1.14]
+    resolute: [libpcl-visualization1.15]
 libpcsclite-dev:
   alpine: [pcsc-lite-dev]
   arch: [pcsclite]


### PR DESCRIPTION
This adds missing PCL dependencies in Resolute to the rosdep database.

## Purpose of using this:

Same as noble, but for resolute

## Distro packaging links:

https://packages.ubuntu.com/search?keywords=libpcl-&searchon=names&suite=resolute&section=all