### PR TITLE
ros2_controllers: 6.9.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8208,6 +8208,7 @@ repositories:
       packages:
       - ackermann_steering_controller
       - admittance_controller
+      - battery_state_broadcaster
       - bicycle_steering_controller
       - chained_filter_controller
       - diff_drive_controller
@@ -8236,7 +8237,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.8.0-1
+      version: 6.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.9.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.8.0-1`

## ackermann_steering_controller

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (#2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Ishan Pathak, Sai Kishor Kothakota
```

## admittance_controller

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Fix admittance position state updates (#2514 <https://github.com/ros-controls/ros2_controllers/issues/2514>)
* admittance_controller userdoc: fix typo (#2479 <https://github.com/ros-controls/ros2_controllers/issues/2479>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Dennis Lanov, Sai Kishor Kothakota, Vladimir Fokow
```

## battery_state_broadcaster

```
* Add battery_state_broadcaster (#2086 <https://github.com/ros-controls/ros2_controllers/issues/2086>)
* Contributors: Christoph Fröhlich, Jonas Otto, Yara Shahin
```

## bicycle_steering_controller

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (#2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Ishan Pathak, Sai Kishor Kothakota
```

## chained_filter_controller

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Sai Kishor Kothakota
```

## diff_drive_controller

```
* Throttle speed limiter parameter error logs (#2546 <https://github.com/ros-controls/ros2_controllers/issues/2546>)
* Allow disabling diff drive command timeout (#2503 <https://github.com/ros-controls/ros2_controllers/issues/2503>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Dennis Lanov, Sai Kishor Kothakota, cyberjay
```

## force_torque_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Fix wrench transformer namespace test flake (#2492 <https://github.com/ros-controls/ros2_controllers/issues/2492>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Dennis Lanov, Sai Kishor Kothakota
```

## forward_command_controller

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## gpio_controllers

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## gps_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## imu_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Sai Kishor Kothakota
```

## joint_state_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* Use preallocated feedback from JTC to avoid heap allocation (#2160 <https://github.com/ros-controls/ros2_controllers/issues/2160>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* [JTC] Fix segfault when continuous joint has no URDF limits (#2480 <https://github.com/ros-controls/ros2_controllers/issues/2480>) (#2523 <https://github.com/ros-controls/ros2_controllers/issues/2523>)
* fix(joint-trajectory-controller): use active tolerances in update step (#2101 <https://github.com/ros-controls/ros2_controllers/issues/2101>)
* Refactor JTC command interface assignment (#2489 <https://github.com/ros-controls/ros2_controllers/issues/2489>)
* Contributors: Dennis Lanov, Dominic Reber, Jeremy McKeehen, Sai Kishor Kothakota
```

## magnetometer_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## mecanum_drive_controller

```
* Throttle speed limiter parameter error logs (#2546 <https://github.com/ros-controls/ros2_controllers/issues/2546>)
* fix: Remove unused variable assignments in mecanum tests (#2534 <https://github.com/ros-controls/ros2_controllers/issues/2534>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Fix safety concerns with halt logic across controllers (#2326 <https://github.com/ros-controls/ros2_controllers/issues/2326>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, cyberjay, lali-perelman
```

## motion_primitives_controllers

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## omni_wheel_drive_controller

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Omni wheel drive odometry update (#2286 <https://github.com/ros-controls/ros2_controllers/issues/2286>)
* Fix safety concerns with halt logic across controllers (#2326 <https://github.com/ros-controls/ros2_controllers/issues/2326>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Devdoot Chatterjee, Sai Kishor Kothakota, lali-perelman
```

## parallel_gripper_controller

```
* fix(parallel_gripper): fix effort and velocity interface lookup (#2318 <https://github.com/ros-controls/ros2_controllers/issues/2318>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Akshay Arjun, Sai Kishor Kothakota
```

## pid_controller

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Sai Kishor Kothakota
```

## pose_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## range_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## ros2_controllers

```
* Add battery_state_broadcaster (#2086 <https://github.com/ros-controls/ros2_controllers/issues/2086>)
* docs: update dead control.ros.org master routes to rolling (#2409 <https://github.com/ros-controls/ros2_controllers/issues/2409>)
* Contributors: Christoph Fröhlich, Ishan Pathak
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Fix another shutdown race with rqt_jtc (#2467 <https://github.com/ros-controls/ros2_controllers/issues/2467>)
* [RQT-JTC] Allow incomplete joint limits (#2404 <https://github.com/ros-controls/ros2_controllers/issues/2404>)
* Contributors: Christoph Fröhlich
```

## state_interfaces_broadcaster

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## steering_controllers_library

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (#2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Fix safety concerns with halt logic across controllers (#2326 <https://github.com/ros-controls/ros2_controllers/issues/2326>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Ishan Pathak, Sai Kishor Kothakota, lali-perelman
```

## tricycle_controller

```
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Contributors: Sai Kishor Kothakota
```

## tricycle_steering_controller

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (#2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>)
* Use new Command/State Interfaces API for tests (#2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>)
* Use new chainable controller exports API (#2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>)
* Contributors: Ishan Pathak, Sai Kishor Kothakota
```
