### PR TITLE
ros2_controllers: 5.17.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8023,6 +8023,7 @@ repositories:
       packages:
       - ackermann_steering_controller
       - admittance_controller
+      - battery_state_broadcaster
       - bicycle_steering_controller
       - chained_filter_controller
       - diff_drive_controller
@@ -8054,7 +8055,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.16.0-1
+      version: 5.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.17.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.16.0-1`

## ackermann_steering_controller

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (backport #2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>) (#2536 <https://github.com/ros-controls/ros2_controllers/issues/2536>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Contributors: mergify[bot]
```

## admittance_controller

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Fix admittance position state updates (backport #2514 <https://github.com/ros-controls/ros2_controllers/issues/2514>) (#2520 <https://github.com/ros-controls/ros2_controllers/issues/2520>)
* admittance_controller userdoc: fix typo (backport #2479 <https://github.com/ros-controls/ros2_controllers/issues/2479>) (#2483 <https://github.com/ros-controls/ros2_controllers/issues/2483>)
* Contributors: mergify[bot]
```

## battery_state_broadcaster

```
* Add battery_state_broadcaster (backport #2086 <https://github.com/ros-controls/ros2_controllers/issues/2086>) (#2522 <https://github.com/ros-controls/ros2_controllers/issues/2522>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (backport #2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>) (#2536 <https://github.com/ros-controls/ros2_controllers/issues/2536>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Contributors: mergify[bot]
```

## chained_filter_controller

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Allow disabling diff drive command timeout (backport #2503 <https://github.com/ros-controls/ros2_controllers/issues/2503>) (#2545 <https://github.com/ros-controls/ros2_controllers/issues/2545>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Fix wrench transformer namespace test flake (backport #2492 <https://github.com/ros-controls/ros2_controllers/issues/2492>) (#2495 <https://github.com/ros-controls/ros2_controllers/issues/2495>)
* Contributors: mergify[bot]
```

## forward_command_controller

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## gpio_controllers

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## gps_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Use preallocated feedback from JTC to avoid heap allocation (backport #2160 <https://github.com/ros-controls/ros2_controllers/issues/2160>) (#2542 <https://github.com/ros-controls/ros2_controllers/issues/2542>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* fix: prevent JTC segfault when continuous joint has no URDF limits (backport #2523 <https://github.com/ros-controls/ros2_controllers/issues/2523>) (#2530 <https://github.com/ros-controls/ros2_controllers/issues/2530>)
* fix(joint-trajectory-controller): use active tolerances in update step (backport #2101 <https://github.com/ros-controls/ros2_controllers/issues/2101>) (#2512 <https://github.com/ros-controls/ros2_controllers/issues/2512>)
* Refactor JTC command assignment for Kilted (#2504 <https://github.com/ros-controls/ros2_controllers/issues/2504>)
* Contributors: Dennis Lanov, mergify[bot]
```

## magnetometer_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

```
* Throttle speed limiter parameter error logs (backport #2546 <https://github.com/ros-controls/ros2_controllers/issues/2546>) (#2548 <https://github.com/ros-controls/ros2_controllers/issues/2548>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* fix: Remove unused variable assignments in mecanum tests (backport #2534 <https://github.com/ros-controls/ros2_controllers/issues/2534>) (#2538 <https://github.com/ros-controls/ros2_controllers/issues/2538>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Fix safety concerns with halt logic across controllers (backport #2326 <https://github.com/ros-controls/ros2_controllers/issues/2326>) (#2459 <https://github.com/ros-controls/ros2_controllers/issues/2459>)
* Contributors: mergify[bot]
```

## motion_primitives_controllers

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* fix: correct test_load_controller tests for motion_primitives and pid_controller (backport #2445 <https://github.com/ros-controls/ros2_controllers/issues/2445>) (#2452 <https://github.com/ros-controls/ros2_controllers/issues/2452>)
* Contributors: mergify[bot]
```

## omni_wheel_drive_controller

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Fix safety concerns with halt logic across controllers (backport #2326 <https://github.com/ros-controls/ros2_controllers/issues/2326>) (#2459 <https://github.com/ros-controls/ros2_controllers/issues/2459>)
* Contributors: mergify[bot]
```

## parallel_gripper_controller

```
* fix(parallel_gripper): fix effort and velocity interface lookup (backport #2318 <https://github.com/ros-controls/ros2_controllers/issues/2318>) (#2557 <https://github.com/ros-controls/ros2_controllers/issues/2557>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## pid_controller

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* fix: correct test_load_controller tests for motion_primitives and pid_controller (backport #2445 <https://github.com/ros-controls/ros2_controllers/issues/2445>) (#2452 <https://github.com/ros-controls/ros2_controllers/issues/2452>)
* Contributors: mergify[bot]
```

## pose_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## ros2_controllers

```
* Add battery_state_broadcaster (backport #2086 <https://github.com/ros-controls/ros2_controllers/issues/2086>) (#2522 <https://github.com/ros-controls/ros2_controllers/issues/2522>)
* Contributors: mergify[bot]
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Fix another shutdown race with rqt_jtc (backport #2467 <https://github.com/ros-controls/ros2_controllers/issues/2467>) (#2552 <https://github.com/ros-controls/ros2_controllers/issues/2552>)
* Contributors: mergify[bot]
```

## state_interfaces_broadcaster

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (backport #2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>) (#2536 <https://github.com/ros-controls/ros2_controllers/issues/2536>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Fix safety concerns with halt logic across controllers (backport #2326 <https://github.com/ros-controls/ros2_controllers/issues/2326>) (#2459 <https://github.com/ros-controls/ros2_controllers/issues/2459>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

```
* fix(steering_controllers): handle NaN/Inf values in odometry update (backport #2083 <https://github.com/ros-controls/ros2_controllers/issues/2083>) (#2536 <https://github.com/ros-controls/ros2_controllers/issues/2536>)
* Use new Command/State Interfaces API for tests (backport #2476 <https://github.com/ros-controls/ros2_controllers/issues/2476>) (#2533 <https://github.com/ros-controls/ros2_controllers/issues/2533>)
* Use new chainable controller exports API (backport #2350 <https://github.com/ros-controls/ros2_controllers/issues/2350>) (#2454 <https://github.com/ros-controls/ros2_controllers/issues/2454>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
