### PR TITLE
ros2_controllers: 4.42.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9858,6 +9858,7 @@ repositories:
       packages:
       - ackermann_steering_controller
       - admittance_controller
+      - battery_state_broadcaster
       - bicycle_steering_controller
       - chained_filter_controller
       - diff_drive_controller
@@ -9890,7 +9891,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.41.0-1
+      version: 4.42.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.42.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.41.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## battery_state_broadcaster

- No changes

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## magnetometer_broadcaster

- No changes

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

```
* fix(parallel_gripper): fix effort and velocity interface lookup (backport #2318 <https://github.com/ros-controls/ros2_controllers/issues/2318>) (#2556 <https://github.com/ros-controls/ros2_controllers/issues/2556>)
* Contributors: mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Fix another shutdown race with rqt_jtc (backport #2467 <https://github.com/ros-controls/ros2_controllers/issues/2467>) (#2551 <https://github.com/ros-controls/ros2_controllers/issues/2551>)
* Contributors: mergify[bot]
```

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
