### PR TITLE
control_toolbox: 6.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1428,7 +1428,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 6.3.0-2
+      version: 6.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `6.4.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.3.0-2`

## control_toolbox

```
* Fix race condition with tf buffer (#654 <https://github.com/ros-controls/control_toolbox/issues/654>)
* Fix testcase for invalid value at node initialization (#615 <https://github.com/ros-controls/control_toolbox/issues/615>)
* Define _USE_MATH_DEFINES for each target that links control_toolbox on WIN32 (#616 <https://github.com/ros-controls/control_toolbox/issues/616>)
* Bump C++ version to C++20 (#599 <https://github.com/ros-controls/control_toolbox/issues/599>)
* Contributors: Christoph Fröhlich, Silvio Traversaro
```
