### PR TITLE
control_toolbox: 5.10.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1404,7 +1404,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.10.0-1
+      version: 5.10.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.10.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.10.0-1`

## control_toolbox

```
* Fix race condition with tf buffer (#654 <https://github.com/ros-controls/control_toolbox/issues/654>) (#656 <https://github.com/ros-controls/control_toolbox/issues/656>)
* Fix testcase for invalid value at node initialization (#615 <https://github.com/ros-controls/control_toolbox/issues/615>) (#632 <https://github.com/ros-controls/control_toolbox/issues/632>)
* Define _USE_MATH_DEFINES for each target that links control_toolbox on WIN32 (#616 <https://github.com/ros-controls/control_toolbox/issues/616>) (#619 <https://github.com/ros-controls/control_toolbox/issues/619>)
* Contributors: mergify[bot]
```
