### PR TITLE
control_toolbox: 4.11.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1921,7 +1921,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.11.0-1
+      version: 4.11.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.11.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.11.0-1`

## control_toolbox

```
* Fix race condition with tf buffer (#654 <https://github.com/ros-controls/control_toolbox/issues/654>) (#655 <https://github.com/ros-controls/control_toolbox/issues/655>)
* Fix testcase for invalid value at node initialization (#615 <https://github.com/ros-controls/control_toolbox/issues/615>) (#631 <https://github.com/ros-controls/control_toolbox/issues/631>)
* Define _USE_MATH_DEFINES for each target that links control_toolbox on WIN32 (#616 <https://github.com/ros-controls/control_toolbox/issues/616>) (#618 <https://github.com/ros-controls/control_toolbox/issues/618>)
* Contributors: mergify[bot]
```
