### PR TITLE
control_toolbox: 3.7.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2040,7 +2040,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.7.0-1
+      version: 3.7.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.7.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.7.0-1`

## control_toolbox

```
* Fix testcase for invalid value at node initialization (backport #615 <https://github.com/ros-controls/control_toolbox/issues/615>) (#630 <https://github.com/ros-controls/control_toolbox/issues/630>)
* Define _USE_MATH_DEFINES for each target that links control_toolbox on WIN32 (#616 <https://github.com/ros-controls/control_toolbox/issues/616>) (#617 <https://github.com/ros-controls/control_toolbox/issues/617>)
* Contributors: dependabot[bot], mergify[bot]
```
