### PR TITLE
rosbridge_suite: 4.2.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8819,7 +8819,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 4.2.0-1
+      version: 4.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `4.2.1-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.2.0-1`

## rosapi

```
* fix: Properly handle an empty list in params_glob
* fix: Correct regex patterns in test_stringify_field_types (#1299 <https://github.com/RobotWebTools/rosbridge_suite/issues/1299>)
* Contributors: Błażej Sowa
```

## rosapi_msgs

- No changes

## rosbridge_library

- No changes

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Prevent event loop starvation by adding a write queue (#1290 <https://github.com/RobotWebTools/rosbridge_suite/issues/1290>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
