### PR TITLE
fusioncore: 0.3.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3497,7 +3497,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.5-1
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fusioncore` to `0.3.6-1`:

- upstream repository: https://github.com/manankharwar/fusioncore
- release repository: https://github.com/manankharwar/fusioncore-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.5-1`
