### PR TITLE
Update REP 143 link in README to reps.openrobotics.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This repository maintains two independent sets of packaging metadata used in ROS:
 
 1. The lists of repositories that curate ROS packages for each ROS distributions,
-   implementing the data structure defined in [REP 143](http://ros.org/reps/rep-0143.html).
+   implementing the data structure defined in [REP 143](https://reps.openrobotics.org/rep-0143/).
    Any ROS package release will generate pull requests to the distribution files
    in this repository.
 


### PR DESCRIPTION
The README linked REP 143 at `http://ros.org/reps/rep-0143.html`, which is stale. Point it at `https://reps.openrobotics.org/rep-0143/`, which serves the current revision.

Fixes #50999