### PR TITLE
mapviz: 4.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5629,7 +5629,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 3.1.0-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `4.0.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.0-1`

## mapviz

```
* Switching to prefer Qt5 over Qt6 for systems where both are installed (#899 <https://github.com/swri-robotics/mapviz/issues/899>)
* Add Helper Functions for New Threading Model (#890 <https://github.com/swri-robotics/mapviz/issues/890>)
* Separate ROS and UI Threads (#887 <https://github.com/swri-robotics/mapviz/issues/887>)
  * Separating ROS and Qt functionality on separate threads. This is an API breaking change, but significantly improves the system responsiveness and performance.
* Fixing wrong profiling code (#886 <https://github.com/swri-robotics/mapviz/issues/886>)
* Update for Deprecated Functionality (#885 <https://github.com/swri-robotics/mapviz/issues/885>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Update Drawn Route When Transforms Change (#902 <https://github.com/swri-robotics/mapviz/issues/902>)
* Improving autocalculation of pointcloud colors (#901 <https://github.com/swri-robotics/mapviz/issues/901>)
* Clear cur_point_ when other points are cleared (#900 <https://github.com/swri-robotics/mapviz/issues/900>)
* Switching to prefer Qt5 over Qt6 for systems where both are installed (#899 <https://github.com/swri-robotics/mapviz/issues/899>)
* Use ellipse z when rendering covariance (#898 <https://github.com/swri-robotics/mapviz/issues/898>)
* Using marker rotation when rendering (#897 <https://github.com/swri-robotics/mapviz/issues/897>)
* Adding option to display markers scaled to either meters or pixels (#895 <https://github.com/swri-robotics/mapviz/issues/895>)
* Render Occupancy Grid with Correct Orientation (#896 <https://github.com/swri-robotics/mapviz/issues/896>)
* Re-Add move_base Plugin (#893 <https://github.com/swri-robotics/mapviz/issues/893>)
* Add Helper Functions for New Threading Model (#890 <https://github.com/swri-robotics/mapviz/issues/890>)
* Separate ROS and UI Threads (#887 <https://github.com/swri-robotics/mapviz/issues/887>)
  * Separating ROS and Qt functionality on separate threads. This is an API breaking change, but significantly improves the system responsiveness and performance.
* Update for Deprecated Functionality (#885 <https://github.com/swri-robotics/mapviz/issues/885>)
* Contributors: David Anthony
```

## multires_image

```
* Switching to prefer Qt5 over Qt6 for systems where both are installed (#899 <https://github.com/swri-robotics/mapviz/issues/899>)
* Adding ROS 2 Version of multires tile loader (#894 <https://github.com/swri-robotics/mapviz/issues/894>)
* Add Helper Functions for New Threading Model (#890 <https://github.com/swri-robotics/mapviz/issues/890>)
* Update for Deprecated Functionality (#885 <https://github.com/swri-robotics/mapviz/issues/885>)
* Contributors: David Anthony
```

## tile_map

```
* Switching to prefer Qt5 over Qt6 for systems where both are installed (#899 <https://github.com/swri-robotics/mapviz/issues/899>)
* Add Helper Functions for New Threading Model (#890 <https://github.com/swri-robotics/mapviz/issues/890>)
* Update for Deprecated Functionality (#885 <https://github.com/swri-robotics/mapviz/issues/885>)
* Contributors: David Anthony
```
