### PR TITLE
swri_console: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12412,7 +12412,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.1.4-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.3.0-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.4-1`

## swri_console

```
* Adding color picker so messages from selected nodes can be highlighted (#87 <https://github.com/swri-robotics/swri_console/issues/87>)
* Adding highlight filter (#86 <https://github.com/swri-robotics/swri_console/issues/86>)
* Adding support for muiltiline format templates (#85 <https://github.com/swri-robotics/swri_console/issues/85>)
* Adding support for RCUTILS_CONSOLE_OUTPUT_FORMAT. Defaults to value set in the environment, and falls back to a user specified value if not in the environment (#84 <https://github.com/swri-robotics/swri_console/issues/84>)
* Using system palette to choose colors instead of hardcoding them so dark mode works (#83 <https://github.com/swri-robotics/swri_console/issues/83>)
* Typing an exclude term now highlights matching log rows instead of hiding them, and only starts actually filtering once the user moves to the next term or shift focus away. (#82 <https://github.com/swri-robotics/swri_console/issues/82>)
* Condense all received messages into one vector when updating the GUI for efficiency (#81 <https://github.com/swri-robotics/swri_console/issues/81>)
* Adding graceful shutdown on SIGINT and SIGTERM from the command line (#80 <https://github.com/swri-robotics/swri_console/issues/80>)
* Fix formatting in README for supported ROS distributions
* Contributors: David Anthony
```
