### PR TITLE
moveit: 2.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4839,7 +4839,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.14.1-2
+      version: 2.15.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.15.0-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.14.1-2`

## chomp_motion_planner

```
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Contributors: Nathan Brooks
```

## moveit

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_common

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_configs_utils

```
* fix setuptools deprecation (#3540 <https://github.com/moveit/moveit2/issues/3540>)
* Contributors: mosfet80
```

## moveit_core

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* moveit_core: dual-support OSQP v0.6.x and v1.0 in AccelerationLimitedPlugin (#3806 <https://github.com/moveit/moveit2/issues/3806>)
  OSQP v1.0 redesigned the C API. A MOVEIT_OSQP_V1 compile guard lets one branch
  support both: Lyrical/Rolling use the moveit-org osqp_vendor fork (OSQP v1.0),
  while Humble/Jazzy/Kilted stay on the apt-shipped v0.6.x.
* Replace shared_ptr::unique() checks (#3793 <https://github.com/moveit/moveit2/issues/3793>)
* resolute: complete ament_index_cpp::get_package_share migration on Rolling (#3705 <https://github.com/moveit/moveit2/issues/3705>)
* resolute: drop octomap version range (#3755 <https://github.com/moveit/moveit2/issues/3755>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Update deprecated usage of get_package_share without std::filesystem::path (#3703 <https://github.com/moveit/moveit2/issues/3703>)
* Fix findWayPointIndicesForDurationAfterStart method when out of bounds (#3626 <https://github.com/moveit/moveit2/issues/3626>)
* normalize quaternion sign for planar joint (#3628 <https://github.com/moveit/moveit2/issues/3628>)
* Populate velocities and accelerations for multidof joint trajectories (#3635 <https://github.com/moveit/moveit2/issues/3635>)
* Replace rclcpp::Rate with rclcpp::WallRate (#3558 <https://github.com/moveit/moveit2/issues/3558>)
* Fix: Fix Trajectory template usage for checkOvershoot with StandardVector (#3617 <https://github.com/moveit/moveit2/issues/3617>)
* Fix build errors for macOS (#3548 <https://github.com/moveit/moveit2/issues/3548>)
* Contributors: Cong Liu, Dhruv Patel, Ezra Brooks, Guilhem Saurel, Joshua Supratman, Nathan Brooks, Shivam Maurya, Stephanie Eng, Tobias Fischer, Xingxin HE
```

## moveit_hybrid_planning

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* De-flake servo and hybrid_planning launch fixtures (#3809 <https://github.com/moveit/moveit2/issues/3809>)
* Use modern --frame-id/--child-frame-id args for test static_transform_publisher (#3762 <https://github.com/moveit/moveit2/issues/3762>)
* resolute: migrate moveit_hybrid_planning off removed position_controllers (#3753 <https://github.com/moveit/moveit2/issues/3753>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Replace rclcpp::Rate with rclcpp::WallRate (#3558 <https://github.com/moveit/moveit2/issues/3558>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Cong Liu, Nathan Brooks, Shivam Maurya
```

## moveit_kinematics

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Fix malformed XML in cached ik kinematics (#3599 <https://github.com/moveit/moveit2/issues/3599>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Guilhem Saurel, Nathan Brooks, Shivam Maurya, mini-1235
```

## moveit_planners

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_planners_chomp

```
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Contributors: Nathan Brooks
```

## moveit_planners_ompl

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* Replace shared_ptr::unique() checks (#3793 <https://github.com/moveit/moveit2/issues/3793>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* [OMPL] also check constraints in StateValidityCallback (#3586 <https://github.com/moveit/moveit2/issues/3586>)
* Update ompl_interface with latest version of OMPL (#2994 <https://github.com/moveit/moveit2/issues/2994>)
* Contributors: Guilhem Saurel, Marq Rasmussen, Matthijs van der Burgh, Nathan Brooks, Shivam Maurya, Tobias Fischer
```

## moveit_planners_stomp

```
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Contributors: Nathan Brooks
```

## moveit_plugins

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_py

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* [macOS] Fix compilation and linking issues in MoveIt2 (#3631 <https://github.com/moveit/moveit2/issues/3631>)
* fix(moveit_py): RobotState.state_info (#3588 <https://github.com/moveit/moveit2/issues/3588>)
* pybind11_vendor is removed in favor of pybind11-dev (#3568 <https://github.com/moveit/moveit2/issues/3568>)
* Contributors: Alejandro Hernández Cordero, Dhruv Patel, Matthijs van der Burgh, Nathan Brooks, Shivam Maurya, Stephanie Eng
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Contributors: Nathan Brooks, Shivam Maurya
```

## moveit_resources_prbt_moveit_config

```
* Use modern --frame-id/--child-frame-id args for test static_transform_publisher (#3762 <https://github.com/moveit/moveit2/issues/3762>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Nathan Brooks, Shivam Maurya
```

## moveit_resources_prbt_pg70_support

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_resources_prbt_support

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_ros

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_ros_benchmarks

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* (rolling)  Fix moveit_ros_benchmarks compile fail (#3593 <https://github.com/moveit/moveit2/issues/3593>)
* Contributors: Nathan Brooks, Shivam Maurya, mosfet80
```

## moveit_ros_control_interface

```
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Fix ERROR stream + check only active controllers for multiple chained controllers (#3556 <https://github.com/moveit/moveit2/issues/3556>)
* Contributors: Guilhem Saurel, Nathan Brooks, thomaspeyrucain
```

## moveit_ros_move_group

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Replace rclcpp::Rate with rclcpp::WallRate (#3558 <https://github.com/moveit/moveit2/issues/3558>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Cong Liu, Guilhem Saurel, Nathan Brooks, Shivam Maurya
```

## moveit_ros_occupancy_map_monitor

```
* resolute: drop octomap version range (#3755 <https://github.com/moveit/moveit2/issues/3755>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Nathan Brooks, Shivam Maurya
```

## moveit_ros_perception

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* resolute: fix depth_image_octomap_updater for image_transport 7.x (#3756 <https://github.com/moveit/moveit2/issues/3756>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* [macOS] Fix compilation and linking issues in MoveIt2 (#3631 <https://github.com/moveit/moveit2/issues/3631>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Dhruv Patel, Nathan Brooks, Shivam Maurya, Stephanie Eng
```

## moveit_ros_planning

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* Replace shared_ptr::unique() checks (#3793 <https://github.com/moveit/moveit2/issues/3793>)
* resolute: complete ament_index_cpp::get_package_share migration on Rolling (#3705 <https://github.com/moveit/moveit2/issues/3705>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Update deprecated usage of get_package_share without std::filesystem::path (#3703 <https://github.com/moveit/moveit2/issues/3703>)
* Shutdown only after all tests are run (#3637 <https://github.com/moveit/moveit2/issues/3637>)
* Replace rclcpp::Rate with rclcpp::WallRate (#3558 <https://github.com/moveit/moveit2/issues/3558>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Cong Liu, Ezra Brooks, Guilhem Saurel, Nathan Brooks, Shivam Maurya, Stephanie Eng, Tobias Fischer
```

## moveit_ros_planning_interface

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* Use modern --frame-id/--child-frame-id args for test static_transform_publisher (#3762 <https://github.com/moveit/moveit2/issues/3762>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Guilhem Saurel, Nathan Brooks, Shivam Maurya
```

## moveit_ros_robot_interaction

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Nathan Brooks, Shivam Maurya
```

## moveit_ros_tests

```
* Use modern --frame-id/--child-frame-id args for test static_transform_publisher (#3762 <https://github.com/moveit/moveit2/issues/3762>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Contributors: Nathan Brooks, Shivam Maurya
```

## moveit_ros_trajectory_cache

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* resolute: GCC 15 / C++20 / rviz API build fixes, and octomap -Werror=cpp suppression (#3760 <https://github.com/moveit/moveit2/issues/3760>)
* De-flake trajectory_cache _with_move_group tests (#3777 <https://github.com/moveit/moveit2/issues/3777>)
* Use modern --frame-id/--child-frame-id args for test static_transform_publisher (#3762 <https://github.com/moveit/moveit2/issues/3762>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Nathan Brooks
```

## moveit_ros_visualization

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* resolute: GCC 15 / C++20 / rviz API build fixes, and octomap -Werror=cpp suppression (#3760 <https://github.com/moveit/moveit2/issues/3760>)
* Fix rviz Qt6 threshold: 15.1 -> 15.1.14 (#3807 <https://github.com/moveit/moveit2/issues/3807>)
  Corrects the gate added in #3707: rviz_common 15.1.0-15.1.13 are still Qt5.
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Use Qt6 on Rolling and newer distros (#3707 <https://github.com/moveit/moveit2/issues/3707>)
  rviz switched to Qt6 in rviz_common 15.1.14. Downstream rviz plugins must build
  against the same Qt major version as the rviz they link.
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Guilhem Saurel, Nathan Brooks, Shivam Maurya
```

## moveit_ros_warehouse

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* CMake: remove boost system (#3727 <https://github.com/moveit/moveit2/issues/3727>)
* Replace rclcpp::Rate with rclcpp::WallRate (#3558 <https://github.com/moveit/moveit2/issues/3558>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Cong Liu, Guilhem Saurel, Nathan Brooks, Shivam Maurya
```

## moveit_runtime

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Contributors: Shivam Maurya
```

## moveit_servo

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* moveit_servo: add explicit <rclcpp/executors.hpp> include in servo_ros_fixture (#3787 <https://github.com/moveit/moveit2/issues/3787>)
* De-flake servo and hybrid_planning launch fixtures (#3809 <https://github.com/moveit/moveit2/issues/3809>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Improve documentation for composeMultiArrayMessage to clarify usage (#3543 <https://github.com/moveit/moveit2/issues/3543>)
* Adjust moveit_servo clock to work with fake_hardware (#3529 <https://github.com/moveit/moveit2/issues/3529>)
* Fix severe warning from class loader in servo (#3577 <https://github.com/moveit/moveit2/issues/3577>)
* Fix deprecations in image_common and tf2_ros (#3567 <https://github.com/moveit/moveit2/issues/3567>)
* Contributors: Himanshu Ravindra Iwanati, Nathan Brooks, Zarnack, bijoua29
```

## moveit_setup_app_plugins

```
* Fix rviz Qt6 threshold: 15.1 -> 15.1.14 (#3807 <https://github.com/moveit/moveit2/issues/3807>)
  Corrects the gate added in #3707: rviz_common 15.1.0-15.1.13 are still Qt5.
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Use Qt6 on Rolling and newer distros (#3707 <https://github.com/moveit/moveit2/issues/3707>)
  rviz switched to Qt6 in rviz_common 15.1.14. Downstream rviz plugins must build
  against the same Qt major version as the rviz they link.
* Contributors: Nathan Brooks
```

## moveit_setup_assistant

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* Fix rviz Qt6 threshold: 15.1 -> 15.1.14 (#3807 <https://github.com/moveit/moveit2/issues/3807>)
  Corrects the gate added in #3707: rviz_common 15.1.0-15.1.13 are still Qt5.
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Use Qt6 on Rolling and newer distros (#3707 <https://github.com/moveit/moveit2/issues/3707>)
  rviz switched to Qt6 in rviz_common 15.1.14. Downstream rviz plugins must build
  against the same Qt major version as the rviz they link.
* Contributors: Nathan Brooks, Shivam Maurya
```

## moveit_setup_controllers

```
* Fix rviz Qt6 threshold: 15.1 -> 15.1.14 (#3807 <https://github.com/moveit/moveit2/issues/3807>)
  Corrects the gate added in #3707: rviz_common 15.1.0-15.1.13 are still Qt5.
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Support parallel_gripper_action_controller in Setup Assistant (#3752 <https://github.com/moveit/moveit2/issues/3752>)
* Use Qt6 on Rolling and newer distros (#3707 <https://github.com/moveit/moveit2/issues/3707>)
  rviz switched to Qt6 in rviz_common 15.1.14. Downstream rviz plugins must build
  against the same Qt major version as the rviz they link.
* Contributors: Nathan Brooks
```

## moveit_setup_core_plugins

```
* Fix rviz Qt6 threshold: 15.1 -> 15.1.14 (#3807 <https://github.com/moveit/moveit2/issues/3807>)
  Corrects the gate added in #3707: rviz_common 15.1.0-15.1.13 are still Qt5.
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Use Qt6 on Rolling and newer distros (#3707 <https://github.com/moveit/moveit2/issues/3707>)
  rviz switched to Qt6 in rviz_common 15.1.14. Downstream rviz plugins must build
  against the same Qt major version as the rviz they link.
* Contributors: Nathan Brooks
```

## moveit_setup_framework

```
* Fix rviz Qt6 threshold: 15.1 -> 15.1.14 (#3807 <https://github.com/moveit/moveit2/issues/3807>)
  Corrects the gate added in #3707: rviz_common 15.1.0-15.1.13 are still Qt5.
* resolute: complete ament_index_cpp::get_package_share migration on Rolling (#3705 <https://github.com/moveit/moveit2/issues/3705>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Update deprecated usage of get_package_share without std::filesystem::path (#3703 <https://github.com/moveit/moveit2/issues/3703>)
* Use Qt6 on Rolling and newer distros (#3707 <https://github.com/moveit/moveit2/issues/3707>)
  rviz switched to Qt6 in rviz_common 15.1.14. Downstream rviz plugins must build
  against the same Qt major version as the rviz they link.
* [macOS] Fix compilation and linking issues in MoveIt2 (#3631 <https://github.com/moveit/moveit2/issues/3631>)
* Contributors: Dhruv Patel, Nathan Brooks, Shivam Maurya, Stephanie Eng
```

## moveit_setup_srdf_plugins

```
* moveit_setup_srdf_plugins: make test_srdf fail loudly instead of segfaulting (#3810 <https://github.com/moveit/moveit2/issues/3810>)
* Fix rviz Qt6 threshold: 15.1 -> 15.1.14 (#3807 <https://github.com/moveit/moveit2/issues/3807>)
  Corrects the gate added in #3707: rviz_common 15.1.0-15.1.13 are still Qt5.
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Migrate from deprecated QVariant::Type::Int to QMetaType::Int (#3712 <https://github.com/moveit/moveit2/issues/3712>)
* Use Qt6 on Rolling and newer distros (#3707 <https://github.com/moveit/moveit2/issues/3707>)
  rviz switched to Qt6 in rviz_common 15.1.14. Downstream rviz plugins must build
  against the same Qt major version as the rviz they link.
* Contributors: Nathan Brooks
```

## moveit_simple_controller_manager

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Contributors: Nathan Brooks, Shivam Maurya
```

## pilz_industrial_motion_planner

```
* resolute: add explicit <cstdint> / <fstream> includes for GCC 15 (#3754 <https://github.com/moveit/moveit2/issues/3754>)
* resolute: GCC 15 / C++20 / rviz API build fixes, and octomap -Werror=cpp suppression (#3760 <https://github.com/moveit/moveit2/issues/3760>)
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* [macOS] Fix compilation and linking issues in MoveIt2 (#3631 <https://github.com/moveit/moveit2/issues/3631>)
* use offset in polyline (#3632 <https://github.com/moveit/moveit2/issues/3632>)
* Feature: New POLYLINE command in Pilz planner for space trajectory generation (#3610 <https://github.com/moveit/moveit2/issues/3610>)
* Contributors: Aiman Taher Abdulmwala Haidar, Dhruv Patel, Nathan Brooks, Shivam Maurya, Stephanie Eng
```

## pilz_industrial_motion_planner_testutils

```
* docs: Updated remaining links from moveit.ros.org to moveit.ai (#3740 <https://github.com/moveit/moveit2/issues/3740>)
* Remove use of ament_target_dependencies: Take 2 (#3726 <https://github.com/moveit/moveit2/issues/3726>)
  ament_target_dependencies is replaced by exported CMake targets. Downstream
  packages should link the namespaced targets (e.g. moveit_ros_planning::moveit_ros_planning).
* Contributors: Nathan Brooks, Shivam Maurya
```
