### PR TITLE
ortools_vendor: 9.9.1-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5803,11 +5803,19 @@ repositories:
       version: rolling
     status: developed
   ortools_vendor:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: 9.9.1
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
-      version: 9.9.0-10
+      version: 9.9.1-4
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: 9.9.1
   osqp_eigen:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.1-4`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/ros2-gbp/ortools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.9.0-10`
