### PR TITLE
ortools_vendor: 9.9.1-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7497,7 +7497,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Fields2Cover/ortools_vendor.git
-      version: 9.9.1
+      version: main
   osqp_eigen:
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7485,11 +7485,19 @@ repositories:
       version: jazzy
     status: developed
   ortools_vendor:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: 9.9.1
     release:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
-      version: 9.9.0-6
+      version: 9.9.1-4
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: 9.9.1
   osqp_eigen:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.1-4`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/ros2-gbp/ortools_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.9.0-6`
