### PR TITLE
ortools_vendor: 9.9.1-3 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6096,11 +6096,19 @@ repositories:
       version: rolling
     status: developed
   ortools_vendor:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: 9.9.1
     release:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
-      version: 9.9.0-11
+      version: 9.9.1-3
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: 9.9.1
   osqp_eigen:
     source:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6108,7 +6108,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Fields2Cover/ortools_vendor.git
-      version: 9.9.1
+      version: main
   osqp_eigen:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.1-3`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/ros2-gbp/ortools_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.9.0-11`
