### PR TITLE
mapviz: 4.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5659,7 +5659,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `4.0.1-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.0-1`

## mapviz

- No changes

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Checking cv_bridge version when setting compile flag instead of ROS_DISTRO (#904 <https://github.com/swri-robotics/mapviz/issues/904>)
* Contributors: David Anthony
```

## multires_image

- No changes

## tile_map

- No changes
