### PR TITLE
sick_safetyscanners_base: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11884,7 +11884,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners_base-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners_base` to `1.0.4-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners_base.git
- release repository: https://github.com/SICKAG/sick_safetyscanners_base-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.3-1`

## sick_safetyscanners_base

```
* Added support for missing I/O scanners and EtherCAT type codes
* Setting C++14 as target property
* Fixing warnings for Wpedantic build
* Adding clang-format file and formatting changes
* Contributors: Christian Eichmann, jncfa-kin
```
