### PR TITLE
mrpt_ros: 2.15.21-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5167,7 +5167,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.20-1
+      version: 2.15.21-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.21-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.20-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

```
* Depend on nanoflann_vendor instead of nanoflann
  The nanoflann rosdep key resolves to the distro's own libnanoflann-dev,
  so it can never select a newer vendored version. Switch to the new
  nanoflann_vendor ROS package name.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

- No changes

## mrpt_libmath

```
* Depend on nanoflann_vendor instead of nanoflann
  The nanoflann rosdep key resolves to the distro's own libnanoflann-dev,
  so it can never select a newer vendored version. Switch to the new
  nanoflann_vendor ROS package name.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

```
* Depend on nanoflann_vendor instead of nanoflann
  The nanoflann rosdep key resolves to the distro's own libnanoflann-dev,
  so it can never select a newer vendored version. Switch to the new
  nanoflann_vendor ROS package name.
* Contributors: Jose Luis Blanco-Claraco
```
