### PR TITLE
mrpt3: 3.1.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5237,7 +5237,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt3-release.git
-      version: 3.1.2-2
+      version: 3.1.3-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.1.3-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.2-2`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

```
* mrpt_bayes: increase code coverage and fix bugs.
  Add unit tests for Kalman and Particle filters. Fix latent bugs in EKF observation Jacobians and CParticleFilterCapable resampling.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_common

```
* cmake: skip building tests on the ROS build farm's dev jobs to prevent timeouts. Use -DMRPT_FORCE_TESTS_ON_ROS_BUILDFARM=ON to override.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_comms

- No changes

## mrpt_config

```
* mrpt_config: increase code coverage and fix bugs.
  Add unit tests for config and options classes. Fix cosmetic padding bug in CConfigFileBase::writeString().
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_containers

```
* test(mrpt_maps): raise unit test coverage for occupancy grids and maps. Fix out-of-bounds reads in CDynamicGrid3D and invert check in computeObservationLikelihood_ConsensusOWA().
* fix(mrpt_containers): guard ts_hash_map self-assignment; extend tests.
* perf(mrpt_system): minimize CTimeLogger enter()/leave() overhead.
* fix(mrpt_system): make CTimeLogger reporting thread-safe vs. concurrent logging.
* test(mrpt_containers): raise unit-test coverage for dynamic grids, circular buffers, ts_hash_map, and YAML.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

- No changes

## mrpt_graphs

- No changes

## mrpt_graphslam

```
* fix(mrpt_graphslam): match fully-qualified class names for constraint-type whitelist. Skip RGBD-TUM info parsing when rawlog is empty.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

```
* fix(mrpt_img): add missing <algorithm> include for std::min/max initializer-list overloads.
* mrpt_img: increase code coverage and fix bugs.
  Add tests across CImage, drawing primitives, and camera classes. Fix bugs in CMappedImage interpolation, RGB-to-HSV conversion, undistort_points, FFT cross-correlation, KLT bounds, and JPEG stream saving.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

- No changes

## mrpt_maps

```
* test(mrpt_maps): raise unit test coverage for occupancy grids and fix minor bugs.
* fix(mrpt_maps): make CPointsMap/CGenericPointsMap tests build on MSVC.
* test(mrpt_maps): extend coverage to octomap, voxelmap, occ3d, and multimap.
* test(mrpt_maps): raise unit-test coverage for random field grids, gas grids, and fix Voronoi clearance pointer issues.
* fix: COccupancyGridMap2D::TLikelihoodOptions::dumpToTextStream bug.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_math

```
* mrpt_math: depend on nanoflann_vendor instead of nanoflann
  The nanoflann rosdep key resolves to the distro's own libnanoflann-dev,
  so it can never select a newer vendored version. Switch to the new
  nanoflann_vendor ROS package name.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav

- No changes

## mrpt_obs

```
* fix: TOPCON doc sign convention, test state leak.
* fix(mrpt_obs): add missing explicit template instantiations for TPixelLabelInfo stream I/O.
* mrpt_obs: increase code coverage and fix bugs across multiple observation classes.
  Fix bugs in CSensoryFrame erase, Velodyne YAML loading, GNSS message types, 3D range scan loading, and 2D scan conversion.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_opengl

```
* test(mrpt_viz): add extensive unit test coverage for mrpt::viz classes.
  Fix bugs in CPolyhedron init, PLY importer, and CMesh3D triangle face-normal computation.
* test(mrpt_viz, mrpt_opengl): add framebuffer regression tests for all drawing primitives.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_poses

- No changes

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

```
* perf(mrpt_system): minimize CTimeLogger enter()/leave() overhead.
* fix(mrpt_system): make CTimeLogger reporting thread-safe vs. concurrent logging.
* fix(mrpt_system): fix GetTempPathA/GetTempFileNameA return value checking and duplicate temp paths on Windows.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tfest

- No changes

## mrpt_topography

```
* fix: TOPCON doc sign convention, test state leak.
* mrpt_topography: increase code coverage and fix bugs in conversions and transforms.
  Fix bugs in geodeticToUTM false northing, geocentricToGeodetic pole singularities, transformHelmert3D unit scaling, and ENUToGeocentric reference axis.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_typemeta

- No changes

## mrpt_viz

```
* test(mrpt_viz): add extensive unit test coverage for mrpt::viz classes.
  Fix bugs in CPolyhedron init, PLY importer, and CMesh3D triangle face-normal computation.
* Contributors: Jose Luis Blanco-Claraco
```
