### PR TITLE
agni_tf_tools: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -129,7 +129,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/agni_tf_tools-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agni_tf_tools` to `1.0.2-1`:

- upstream repository: https://github.com/ubi-agni/agni_tf_tools.git
- release repository: https://github.com/ros2-gbp/agni_tf_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.1-1`

## agni_tf_tools

```
* Initialize StaticTransformBroadcaster from Node reference instead of pointer
* Contributors: Robert Haschke
```
