### PR TITLE
moveit_msgs: 2.7.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5073,7 +5073,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.7.1-3
+      version: 2.7.2-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.7.2-1`:

- upstream repository: https://github.com/moveit/moveit_msgs.git
- release repository: https://github.com/ros2-gbp/moveit_msgs-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.7.1-3`

## moveit_msgs

```
* Add smoothness_level for FREE path Pilz command (#190 <https://github.com/ros-planning/moveit_msgs/issues/190>)
* Contributors: AimanHaidar
```
