### PR TITLE
add example_robot_data on rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2106,6 +2106,13 @@ repositories:
       url: https://github.com/ros2/example_interfaces.git
       version: rolling
     status: maintained
+  example_robot_data:
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/gepetto/example-robot-data.git
+      version: devel
+    status: maintained
   examples:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

example_robot_data, a set of robot URDFs for benchmarking and developed examples

# The source is here:

https://github.com/Gepetto/example-robot-data

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
