### PR TITLE
jrl_cmakemodules: 2.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4756,7 +4756,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
-      version: 2.0.0-1
+      version: 2.2.4-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jrl_cmakemodules` to `2.2.4-1`:

- upstream repository: https://github.com/jrl-umi3218/jrl-cmakemodules
- release repository: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-1`
