### PR TITLE
mapviz: 4.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5634,7 +5634,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `4.0.2-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.1-1`

## mapviz

```
* mapviz: Export pkg-config dependency (#905 <https://github.com/swri-robotics/mapviz/issues/905>)
* Contributors: Michal Sojka
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

- No changes
