### PR TITLE
gps_umd: 3.1.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2818,7 +2818,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `3.1.1-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.0-1`

## gps_msgs

- No changes

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

```
* Improved check for constant definition, and adding dependency on pkg-config to find gpsd (#128 <https://github.com/swri-robotics/gps_umd/issues/128>)
* Contributors: David Anthony
```
