### PR TITLE
Add wirestead and wirestead_ros source entries (jazzy)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -14415,6 +14415,26 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: foxy-devel
     status: maintained
+  wirestead:
+    doc:
+      type: git
+      url: https://github.com/wirestead/wirestead.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/wirestead/wirestead.git
+      version: main
+    status: developed
+  wirestead_ros:
+    doc:
+      type: git
+      url: https://github.com/wirestead/wirestead-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/wirestead/wirestead-ros.git
+      version: main
+    status: developed
   wrapyfi_ros2_interfaces:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -14415,26 +14415,6 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: foxy-devel
     status: maintained
-  wirestead:
-    doc:
-      type: git
-      url: https://github.com/wirestead/wirestead.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/wirestead/wirestead.git
-      version: main
-    status: developed
-  wirestead_ros:
-    doc:
-      type: git
-      url: https://github.com/wirestead/wirestead-ros.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/wirestead/wirestead-ros.git
-      version: main
-    status: developed
   wrapyfi_ros2_interfaces:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -13903,20 +13903,12 @@ repositories:
       version: humble
     status: maintained
   wirestead:
-    doc:
-      type: git
-      url: https://github.com/wirestead/wirestead.git
-      version: main
     source:
       type: git
       url: https://github.com/wirestead/wirestead.git
       version: main
     status: developed
   wirestead_ros:
-    doc:
-      type: git
-      url: https://github.com/wirestead/wirestead-ros.git
-      version: main
     source:
       type: git
       url: https://github.com/wirestead/wirestead-ros.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -13828,6 +13828,26 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: humble
     status: maintained
+  wirestead:
+    doc:
+      type: git
+      url: https://github.com/wirestead/wirestead.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/wirestead/wirestead.git
+      version: main
+    status: developed
+  wirestead_ros:
+    doc:
+      type: git
+      url: https://github.com/wirestead/wirestead-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/wirestead/wirestead-ros.git
+      version: main
+    status: developed
   xacro:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Jazzy source entries only. Humble is split out into #53541, per `REVIEW_GUIDELINES.md`.

# The source is here:

- https://github.com/wirestead/wirestead.git — `wirestead`, a cross-platform asynchronous C++20 communication library for serial, TCP, UDP and Unix domain sockets. Plain CMake, so `colcon list` reports it as `wirestead (ros.cmake)`.
- https://github.com/wirestead/wirestead-ros.git — `wirestead_ros`, the ament package providing the ROS 2 integration layer on top of it.

`release` entries will follow from bloom: the `ros2-gbp` new-release-team template asks for a link to a merged source entry first, which is what this pull request is for.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

Both repositories are public, carry a top-level `LICENSE`, declare `Apache-2.0` in every `package.xml`, follow REP-144, and are not forks of existing ROS packages. Neither is present in any distribution yet. CI builds and tests both on Ubuntu Noble amd64 and arm64.
