### PR TITLE
moveit_task_constructor: 0.1.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4901,7 +4901,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_task_constructor-release.git
-      version: 0.1.5-2
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/moveit/moveit_task_constructor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_task_constructor` to `0.1.6-1`:

- upstream repository: https://github.com/moveit/moveit_task_constructor.git
- release repository: https://github.com/ros2-gbp/moveit_task_constructor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.5-2`

## moveit_task_constructor_capabilities

```
* Support Ubuntu 26.04 and Qt6 (#758 <https://github.com/moveit/moveit_task_constructor/issues/758>)
* Contributors: Nathan Brooks, Robert Haschke
```

## moveit_task_constructor_core

```
* Support Ubuntu 26.04 and Qt6 (#758 <https://github.com/moveit/moveit_task_constructor/issues/758>)
* Modernize fmt usage (#755 <https://github.com/moveit/moveit_task_constructor/issues/755>, #756 <https://github.com/moveit/moveit_task_constructor/issues/756>)
* Add Windows socket header inclusion (#751 <https://github.com/moveit/moveit_task_constructor/issues/751>)
* LimitSolutions: prevent child compute calls after max_solutions is reached (#745 <https://github.com/moveit/moveit_task_constructor/issues/745>)
* Contributors: Aaron Chong, Daniel García López, Dhruv Patel, Nathan Brooks, Robert Haschke, Tobias Fischer
```

## moveit_task_constructor_demo

```
* Cleanup demo/package.xml
* Contributors: Robert Haschke
```

## moveit_task_constructor_msgs

- No changes

## moveit_task_constructor_visualization

```
* Handle signature change of rviz::Display::update
* Support Ubuntu 26.04 and Qt6 (#758 <https://github.com/moveit/moveit_task_constructor/issues/758>)
* Modernize fmt usage (#756 <https://github.com/moveit/moveit_task_constructor/issues/756>)
* Store ExecutionInfo in rviz' DisplaySolution (#749 <https://github.com/moveit/moveit_task_constructor/issues/749>)
* Contributors: Dhruv Patel, Nathan Brooks, Robert Haschke, lunarifish
```

## rviz_marker_tools

- No changes
