### PR TITLE
add memfd_buffer_backend to lyrical

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4590,6 +4590,12 @@ repositories:
       url: https://github.com/mavlink/mavros.git
       version: ros2
     status: developed
+  memfd_buffer_backend:
+    source:
+      type: git
+      url: https://github.com/dskkato/memfd_buffer_backend.git
+      version: lyrical
+    status: developed
   menge_vendor:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

lyrical

# The source is here:

https://github.com/dskkato/memfd_buffer_backend.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
