### PR TITLE
adi_imu: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -126,7 +126,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/adi_imu-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/imu_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_imu` to `1.0.1-1`:

- upstream repository: https://github.com/analogdevicesinc/imu_ros2.git
- release repository: https://github.com/ros2-gbp/adi_imu-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## adi_imu

```
* Add IMU covariance estimation framework with selectable algorithms:
  Static, Welford, Sliding Window, EWMA, and Kalman.
* Add covariance-enabled launch/config support, including algorithm and
  motion-detection parameters.
* Add motion-aware covariance updates via MotionDetector integration in
  adaptive estimators (EWMA, Sliding Window, Kalman).
* Fix IMU covariance semantics in published messages: keep orientation
  covariance invalid (-1) and use all-zero defaults for unknown linear
  acceleration and angular velocity covariance (Fixes #80).
* Fix double-free in imu_ros2_node data-provider lifecycle handling
  (prevents SIGSEGV).
* Add configurable IMU frame_id parameter (#77).
* Improve robustness and maintenance:
  update CI to ROS 2 Humble only, fix launch variable typo, improve
  buffered delta-channel handling in IIOWrapper, and update documentation
  (including 3rd-party license references).
* Contributors: Adrian-Stanea, Ioan Dragomir, Tudor-Alinei-poiana_adi, laurent-19
```
