### PR TITLE
Add splat_interfaces to ROS Rolling, Kilted and Jazzy index

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12130,6 +12130,12 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: jazzy
     status: maintained
+  splat_interfaces:
+    source:
+      type: git
+      url: https://github.com/splat-ros/splat_interfaces.git
+      version: main
+    status: developed
   srdfdom:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9985,6 +9985,12 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: kilted
     status: maintained
+  splat_interfaces:
+    source:
+      type: git
+      url: https://github.com/splat-ros/splat_interfaces.git
+      version: main
+    status: developed
   srdfdom:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9878,6 +9878,12 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: rolling
     status: maintained
+  splat_interfaces:
+    source:
+      type: git
+      url: https://github.com/splat-ros/splat_interfaces.git
+      version: main
+    status: developed
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
gsplat_msgs has moved out of RVizSplat (already tracked as `rviz_splat`) into a new repo, splat_interfaces. 

This PR adds a source-only entry for it so buildfarm devel/source jobs for RVizSplat can resolve the dependency again

## Package name:

- gsplat_msgs

## Package Upstream Source:

https://github.com/splat-ros/splat_interfaces

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro