### PR TITLE
unbag: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -13203,6 +13203,17 @@ repositories:
       url: https://github.com/flynneva/udp_msgs.git
       version: main
     status: maintained
+  unbag:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/unbag-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/ros2_unbag.git
+      version: main
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `unbag` to `1.3.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/ros2_unbag.git
- release repository: https://github.com/ros2-gbp/unbag-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
