### PR TITLE
adi_iio: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -114,6 +114,11 @@ repositories:
       type: git
       url: https://github.com/analogdevicesinc/iio_ros2.git
       version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/adi_iio-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/iio_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_iio` to `1.1.0-1`:

- upstream repository: https://github.com/analogdevicesinc/iio_ros2.git
- release repository: https://github.com/ros2-gbp/adi_iio-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## adi_iio

```
* Tests: stabilize smoke and attr_topic tests with service/topic discovery waits, failure cleanup, and warmup-aware rate checks.
* Build system: require CMake 3.14 and remove deprecated ament_target_dependencies usage.
* Node services: use service-specific QoS in adi_iio services.
* Contributors: Adrian-Stanea
```
