### PR TITLE
adi_imu: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -124,6 +124,11 @@ repositories:
       type: git
       url: https://github.com/analogdevicesinc/imu_ros2.git
       version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/adi_imu-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/imu_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_imu` to `1.1.0-1`:

- upstream repository: https://github.com/analogdevicesinc/imu_ros2.git
- release repository: https://github.com/ros2-gbp/adi_imu-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## adi_imu

```
* CMake: raise minimum required version to 3.14 and remove deprecated ament dependency usage.
* Contributors: Adrian-Stanea
```
