### PR TITLE
adi_iio: 1.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -121,11 +121,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/analogdevicesinc/iio_ros2.git
-      version: rolling
+      version: lyrical
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/adi_iio-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/iio_ros2.git
-      version: rolling
+      version: lyrical
     status: maintained
   adi_imu:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_iio` to `1.1.0-1`:

- upstream repository: https://github.com/analogdevicesinc/iio_ros2.git
- release repository: https://github.com/ros2-gbp/adi_iio-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## adi_iio

```
* Tests: stabilize smoke and attr_topic tests with service/topic discovery waits, failure cleanup, and warmup-aware rate checks.
* Build system: require CMake 3.14 and remove deprecated ament_target_dependencies usage.
* Node services: use service-specific QoS in adi_iio services.
* Contributors: Adrian-Stanea
```
