### PR TITLE
crazyswarm2: 1.0.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1514,12 +1514,13 @@ repositories:
       - crazyflie_examples
       - crazyflie_interfaces
       - crazyflie_py
+      - crazyflie_server_cpp
       - crazyflie_server_py
       - crazyflie_sim
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/crazyswarm2-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/IMRCLab/crazyswarm2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crazyswarm2` to `1.0.6-1`:

- upstream repository: https://github.com/IMRCLab/crazyswarm2.git
- release repository: https://github.com/ros2-gbp/crazyswarm2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.5-1`

## crazyflie

```
* Fix matrix shape order and add configurable image encoding
* Separate Crazyflie cpp server
* Add default_topics.imu as sensor_msgs/Imu
* cpp-server: fix compiler error on rolling
* Contributors: Alvaro Gaona, Anna, Kimberly McGuire, Wolfgang Hönig
```

## crazyflie_description

- No changes

## crazyflie_examples

- No changes

## crazyflie_interfaces

- No changes

## crazyflie_py

```
* Remove rowan dependency
* Contributors: Wolfgang Hönig
```

## crazyflie_server_cpp

```
* Separate Crazyflie cpp server
* Contributors: Kimberly McGuire
```

## crazyflie_server_py

```
* Add default_topics.imu as sensor_msgs/Imu
* Fix: add /all/notify_setpoints_stop service in crazyflie_server.py
* Contributors: Alvaro Gaona, Kimberly McGuire, Wolfgang Hönig, toyomoy
```

## crazyflie_sim

```
* Remove rowan dependency
* Contributors: Wolfgang Hönig
```
