### PR TITLE
kangaroo_robot: 2.15.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4787,7 +4787,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kangaroo_robot-release.git
-      version: 2.14.1-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/kangaroo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kangaroo_robot` to `2.15.0-1`:

- upstream repository: https://github.com/pal-robotics/kangaroo_robot.git
- release repository: https://github.com/ros2-gbp/kangaroo_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.14.1-1`

## kangaroo_bringup

```
* Proper launch of the rh8d driver
  See merge request robots/kangaroo_robot!171
* Removing passing use_mimic to the rh8d
  use_mimic now only controls the leg chain and it's passed down properly
  the launch files
* Contributors: Sai Kishor Kothakota, Óscar Martínez
```

## kangaroo_controller_configuration

```
* Proper launch of the rh8d driver
  See merge request robots/kangaroo_robot!171
* Adding path to launch rh8d controller
  It will load different rh8d ros2 control config depending if it's sim or
  not.
* Contributors: Sai Kishor Kothakota, Óscar Martínez
```

## kangaroo_description

```
* Proper launch of the rh8d driver
  See merge request robots/kangaroo_robot!171
* Adding path to launch rh8d controller
  It will load different rh8d ros2 control config depending if it's sim or
  not.
* Removing passing use_mimic to the rh8d
  use_mimic now only controls the leg chain and it's passed down properly
  the launch files
* Contributors: Sai Kishor Kothakota, Óscar Martínez
```

## kangaroo_robot

- No changes
