### PR TITLE
pal_sea_arm: 2.8.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7978,7 +7978,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_sea_arm-release.git
-      version: 2.6.0-1
+      version: 2.8.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm` to `2.8.4-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm.git
- release repository: https://github.com/ros2-gbp/pal_sea_arm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.6.0-1`

## pal_sea_arm

- No changes

## pal_sea_arm_bringup

- No changes

## pal_sea_arm_controller_configuration

- No changes

## pal_sea_arm_description

```
* Adding missing rh8d description dep
* Contributors: oscarmartinez
```
