### PR TITLE
kangaroo_moveit_config: 2.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4768,6 +4768,11 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/kangaroo_moveit_config.git
       version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/kangaroo_moveit_config-release.git
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/kangaroo_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kangaroo_moveit_config` to `2.2.2-1`:

- upstream repository: https://github.com/pal-robotics/kangaroo_moveit_config.git
- release repository: https://github.com/ros2-gbp/kangaroo_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## kangaroo_moveit_config

```
* Add missing dependency kangaroo_description
* Contributors: Noel Jimenez
```
