### PR TITLE
Mark pal_navigation_cfg_public end-of-life

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7922,7 +7922,7 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/pal_navigation_cfg_public.git
       version: humble-devel
-    status: developed
+    status: end-of-life
   pal_pro_gripper:
     doc:
       type: git


### PR DESCRIPTION
This repo is not used anymore, so I'm marking it end-of-life