### PR TITLE
tiago_pro_robot: 2.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12952,7 +12952,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_robot-release.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_robot` to `2.5.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_robot.git
- release repository: https://github.com/ros2-gbp/tiago_pro_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.0-1`

## tiago_pro_bringup

```
* New boxing position
* Contributors: Rafa Rojas
```

## tiago_pro_controller_configuration

- No changes

## tiago_pro_description

- No changes

## tiago_pro_robot

- No changes
