### PR TITLE
tiago_dual_moveit_config: 2.0.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12775,6 +12775,11 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_moveit_config.git
       version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/tiago_dual_moveit_config-release.git
+      version: 2.0.11-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_dual_moveit_config` to `2.0.11-1`:

- upstream repository: https://github.com/pal-robotics/tiago_dual_moveit_config.git
- release repository: https://github.com/ros2-gbp/tiago_dual_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## tiago_dual_moveit_config

```
* ineractive marker
* Contributors: Vamsi GUDA
```
