### PR TITLE
tiago_pro_navigation: 2.15.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12932,7 +12932,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_navigation-release.git
-      version: 2.14.0-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_navigation` to `2.15.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_navigation.git
- release repository: https://github.com/ros2-gbp/tiago_pro_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.14.0-1`

## tiago_pro_2dnav

```
* adapt eulero refactor
* Contributors: antoniobrandi
```

## tiago_pro_laser_sensors

- No changes

## tiago_pro_navigation

- No changes

## tiago_pro_rgbd_sensors

- No changes
