### PR TITLE
pal_statistics: 2.8.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6210,7 +6210,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.8.0-1
+      version: 2.8.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.8.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.8.0-1`

## pal_statistics

```
* Merge branch 'fix/link-atomic' into 'humble-devel'
  Link atomic library
  See merge request qa/pal_statistics!62
* Link atomic library if needed
* Contributors: Mathias Lüdtke, Sai Kishor Kothakota
```

## pal_statistics_msgs

- No changes
