### PR TITLE
mujoco_ros2_control: 0.1.0-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5238,6 +5238,7 @@ repositories:
       version: main
     release:
       packages:
+      - mujoco_3d_lidar
       - mujoco_ros2_control
       - mujoco_ros2_control_demos
       - mujoco_ros2_control_msgs
@@ -5245,7 +5246,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
-      version: 0.0.3-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/ros-controls/mujoco_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_ros2_control` to `0.1.0-2`:

- upstream repository: https://github.com/ros-controls/mujoco_ros2_control.git
- release repository: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.3-1`

## mujoco_3d_lidar

```
* Make CI tests more robust (#239 <https://github.com/ros-controls/mujoco_ros2_control/issues/239>)
  * Protect lidar timestamps from uninitialized plugin data
  * Different software and llvmpipe for tests
  * Actually wait for rendering and skip the tests if it's broken
  * Actually fail explicitly for uninitialized contexts
  * Remove magic numbers, standardize sleep, fix comments
* Add Plugin for the 3D Lidar Extension (#207 <https://github.com/ros-controls/mujoco_ros2_control/issues/207>)
  * Add a 3D Lidar ROS 2 plugin
  * Fix merge issues and updated plugin build
  * Support async lidar
  * More ament build fun for rolling
  * Format fixes
  * fat fingered format fix
  * Ensure the plugin is available for tests
  * Clear out extra file
  * Self review, and minor cleanup
  * Make example crazy
  * Consolidate branches
  * Add doc
  * Add test, more logs
  * More test cleanup
  * Start times at 0
  * Possibly fix mujoco_vendor
  * Lamdas, so hot right now
  * Docs and comment nits
* Update Pixi packages with pixi.lock (#223 <https://github.com/ros-controls/mujoco_ros2_control/issues/223>)
  * Update Pixi packages with pixi.lock
  * Conditional plugin init macro for diff mujoco versions
  * Formatting
  * One more lock update for good luck
  * dupe ns
  * Pin pytest to compatible version
  ---------
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Add a 3-D Lidar Extension (#205 <https://github.com/ros-controls/mujoco_ros2_control/issues/205>)
  * Add standalone mujoco 3d lidar plugin
  * Add note about removing update rate to the readme
  * Rename to extensions
  * Add docs
  * Add extension docs
  * Update demo robots
  * fix path
  * Use ament for plugin identification
  * add todo
  * Fix pid xml
  * PR comments
  * Remove extraneous paths in lidar
  * mj_multiRay hasn't changed
  * Add a do nothing extension, can revert
  * Update mujoco_extensions/mujoco_3d_lidar/CMakeLists.txt
  Co-authored-by: Nathan Dunkelberger <mailto:138718889+ndunkelb-nasa@users.noreply.github.com>
  * source for ament before testing
  * Revert "Add a do nothing extension, can revert"
  This reverts commit 1f64aacfe715f916765f806f02d0d42326b6bc36.
  * fix typo
  * Update deps
  * Update docs
  * Remove the lidar extension from the demos for now
  * Update include and build
  * SebC nits
  * Fix out of bounds access
  * PR comments
  ---------
  Co-authored-by: Nathan Dunkelberger <mailto:138718889+ndunkelb-nasa@users.noreply.github.com>
* Contributors: Erik Holum, Sai Kishor Kothakota
* Make CI tests more robust (#239 <https://github.com/ros-controls/mujoco_ros2_control/issues/239>)
  * Protect lidar timestamps from uninitialized plugin data
  * Different software and llvmpipe for tests
  * Actually wait for rendering and skip the tests if it's broken
  * Actually fail explicitly for uninitialized contexts
  * Remove magic numbers, standardize sleep, fix comments
* Add Plugin for the 3D Lidar Extension (#207 <https://github.com/ros-controls/mujoco_ros2_control/issues/207>)
  * Add a 3D Lidar ROS 2 plugin
  * Fix merge issues and updated plugin build
  * Support async lidar
  * More ament build fun for rolling
  * Format fixes
  * fat fingered format fix
  * Ensure the plugin is available for tests
  * Clear out extra file
  * Self review, and minor cleanup
  * Make example crazy
  * Consolidate branches
  * Add doc
  * Add test, more logs
  * More test cleanup
  * Start times at 0
  * Possibly fix mujoco_vendor
  * Lamdas, so hot right now
  * Docs and comment nits
* Update Pixi packages with pixi.lock (#223 <https://github.com/ros-controls/mujoco_ros2_control/issues/223>)
  * Update Pixi packages with pixi.lock
  * Conditional plugin init macro for diff mujoco versions
  * Formatting
  * One more lock update for good luck
  * dupe ns
  * Pin pytest to compatible version
  ---------
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Add a 3-D Lidar Extension (#205 <https://github.com/ros-controls/mujoco_ros2_control/issues/205>)
  * Add standalone mujoco 3d lidar plugin
  * Add note about removing update rate to the readme
  * Rename to extensions
  * Add docs
  * Add extension docs
  * Update demo robots
  * fix path
  * Use ament for plugin identification
  * add todo
  * Fix pid xml
  * PR comments
  * Remove extraneous paths in lidar
  * mj_multiRay hasn't changed
  * Add a do nothing extension, can revert
  * Update mujoco_extensions/mujoco_3d_lidar/CMakeLists.txt
  Co-authored-by: Nathan Dunkelberger <mailto:138718889+ndunkelb-nasa@users.noreply.github.com>
  * source for ament before testing
  * Revert "Add a do nothing extension, can revert"
  This reverts commit 1f64aacfe715f916765f806f02d0d42326b6bc36.
  * fix typo
  * Update deps
  * Update docs
  * Remove the lidar extension from the demos for now
  * Update include and build
  * SebC nits
  * Fix out of bounds access
  * PR comments
  ---------
  Co-authored-by: Nathan Dunkelberger <mailto:138718889+ndunkelb-nasa@users.noreply.github.com>
* Contributors: Erik Holum, Sai Kishor Kothakota
```

## mujoco_ros2_control

```
* Add a pre-step callback to the simulation (#282 <https://github.com/ros-controls/mujoco_ros2_control/issues/282>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Fix control mode selection (#281 <https://github.com/ros-controls/mujoco_ros2_control/issues/281>)
* Support intvelocity actuators (#271 <https://github.com/ros-controls/mujoco_ros2_control/issues/271>)
* Add base twist plugin for commanding the mobile base (#254 <https://github.com/ros-controls/mujoco_ros2_control/issues/254>)
* Refine reset world overrides functionality (#263 <https://github.com/ros-controls/mujoco_ros2_control/issues/263>)
* Support joint overrides in reset world service (#256 <https://github.com/ros-controls/mujoco_ros2_control/issues/256>)
* Support multiple sets of state interfaces from multiple sensor tags with same name (#258 <https://github.com/ros-controls/mujoco_ros2_control/issues/258>)
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* [Fix] Don't overwrite transmission-driven joint states in the direct-copy fallback (#259 <https://github.com/ros-controls/mujoco_ros2_control/issues/259>)
* [doc] Fix undefined label errors (#260 <https://github.com/ros-controls/mujoco_ros2_control/issues/260>)
* Add support for Magnetometer sensor (#257 <https://github.com/ros-controls/mujoco_ros2_control/issues/257>)
* [Feature] modify elements of geom attribute (#244 <https://github.com/ros-controls/mujoco_ros2_control/issues/244>)
* Add missing dependencies (#250 <https://github.com/ros-controls/mujoco_ros2_control/issues/250>)
* [CI] Fix dependency declarations for bloom (#226 <https://github.com/ros-controls/mujoco_ros2_control/issues/226>)
* Fix transmissions integration working with multiple actuators (#241 <https://github.com/ros-controls/mujoco_ros2_control/issues/241>)
  Co-authored-by: Daniel Costanzi <mailto:daniel.costanzi@pal-robotics.com>
* Add service to set the free joint body state (#233 <https://github.com/ros-controls/mujoco_ros2_control/issues/233>)
* Fix links in interface docs, use auto label generator like the upstream (#238 <https://github.com/ros-controls/mujoco_ros2_control/issues/238>)
* Fix state passed into pose sensors (#231 <https://github.com/ros-controls/mujoco_ros2_control/issues/231>)
* Fix controller manager rate collapse by decoupling control and physics locks (#224 <https://github.com/ros-controls/mujoco_ros2_control/issues/224>)
* Use updated ament_index_cpp interfaces, re-add rolling (#229 <https://github.com/ros-controls/mujoco_ros2_control/issues/229>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Add a 3-D Lidar Extension (#205 <https://github.com/ros-controls/mujoco_ros2_control/issues/205>)
  Co-authored-by: Nathan Dunkelberger <mailto:138718889+ndunkelb-nasa@users.noreply.github.com>
* Add support for "site" transmission type (#154 <https://github.com/ros-controls/mujoco_ros2_control/issues/154>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Add support for pose sensors (#220 <https://github.com/ros-controls/mujoco_ros2_control/issues/220>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Fix deprecations in ament_index_cpp (#145 <https://github.com/ros-controls/mujoco_ros2_control/issues/145>)
  Co-authored-by: Julia Jia <mailto:juliajster@gmail.com>
* Fix race condition on sim-display overlay text (#222 <https://github.com/ros-controls/mujoco_ros2_control/issues/222>)
* Display the sim real time factor on the native viewer (#189 <https://github.com/ros-controls/mujoco_ros2_control/issues/189>)
* Refactor Rangefinder base Lidar as a Plugin (#214 <https://github.com/ros-controls/mujoco_ros2_control/issues/214>)
* Refactor RGB-D Cameras to a Plugin (#211 <https://github.com/ros-controls/mujoco_ros2_control/issues/211>)
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Add 'lyrical' to ros_distro matrix in CI workflow (#213 <https://github.com/ros-controls/mujoco_ros2_control/issues/213>)
* Fix scipy for openblas missing dependency (#212 <https://github.com/ros-controls/mujoco_ros2_control/issues/212>)
* Isolate flakey functional tests and update pixi (#204 <https://github.com/ros-controls/mujoco_ros2_control/issues/204>)
* Support/cameras rendering/headless (#197 <https://github.com/ros-controls/mujoco_ros2_control/issues/197>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Fix glfw initialization on headless run (#200 <https://github.com/ros-controls/mujoco_ros2_control/issues/200>)
* Add changes for mujoco vendor bump (#202 <https://github.com/ros-controls/mujoco_ros2_control/issues/202>)
* Control and plugin data input cleanup (#191 <https://github.com/ros-controls/mujoco_ros2_control/issues/191>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Migrate documentation to rst format for control.ros.org (#188 <https://github.com/ros-controls/mujoco_ros2_control/issues/188>)
* Refactor the core mujoco simulation to be in its own container (#175 <https://github.com/ros-controls/mujoco_ros2_control/issues/175>)
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Handle topic model loading failures with nullptr instead of exit (#183 <https://github.com/ros-controls/mujoco_ros2_control/issues/183>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Improve LiDAR validation in URDF-to-MJCF conversion (#182 <https://github.com/ros-controls/mujoco_ros2_control/issues/182>)
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Fix Sphinx xref_missing reference (#186 <https://github.com/ros-controls/mujoco_ros2_control/issues/186>)
* Handle duplicate mesh file names in the conversion tool (#171 <https://github.com/ros-controls/mujoco_ros2_control/issues/171>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Contributors: Christian Rauch, Christoph Fröhlich, Erik Holum, Lang Qinglin, Marq Rasmussen, Ortisa, Sai Kishor Kothakota, Sebastian Castro, Tianlin Zhang, danielcostanzi18, msavchen-nasa
```

## mujoco_ros2_control_demos

```
* Add base twist plugin for commanding the mobile base (#254 <https://github.com/ros-controls/mujoco_ros2_control/issues/254>)
* Add support for Magnetometer sensor (#257 <https://github.com/ros-controls/mujoco_ros2_control/issues/257>)
* Add missing dependencies (#250 <https://github.com/ros-controls/mujoco_ros2_control/issues/250>)
* MuJoCo free joints state publisher plugin (#247 <https://github.com/ros-controls/mujoco_ros2_control/issues/247>)
* Fix transmissions integration working with multiple actuators (#241 <https://github.com/ros-controls/mujoco_ros2_control/issues/241>)
  Co-authored-by: Daniel Costanzi <mailto:daniel.costanzi@pal-robotics.com>
* Add service to set the free joint body state (#233 <https://github.com/ros-controls/mujoco_ros2_control/issues/233>)
* Add pose sensor test to launch tests (#232 <https://github.com/ros-controls/mujoco_ros2_control/issues/232>)
  Co-authored-by: Sebastian Castro <mailto:sebastian.a.castrofernandez@nasa.gov>
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Fix state passed into pose sensors (#231 <https://github.com/ros-controls/mujoco_ros2_control/issues/231>)
* remove shebangs from launch files (#227 <https://github.com/ros-controls/mujoco_ros2_control/issues/227>)
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Add support for pose sensors (#220 <https://github.com/ros-controls/mujoco_ros2_control/issues/220>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Support polling, streaming, and disabled cameras in camera plugin (#217 <https://github.com/ros-controls/mujoco_ros2_control/issues/217>)
* Refactor Rangefinder base Lidar as a Plugin (#214 <https://github.com/ros-controls/mujoco_ros2_control/issues/214>)
* Refactor RGB-D Cameras to a Plugin (#211 <https://github.com/ros-controls/mujoco_ros2_control/issues/211>)
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Migrate documentation to rst format for control.ros.org (#188 <https://github.com/ros-controls/mujoco_ros2_control/issues/188>)
* Contributors: Christian Rauch, Erik Holum, Sai Kishor Kothakota, Sebastian Castro, msavchen-nasa
```

## mujoco_ros2_control_msgs

```
* Refine reset world overrides functionality (#263 <https://github.com/ros-controls/mujoco_ros2_control/issues/263>)
* Support joint overrides in reset world service (#256 <https://github.com/ros-controls/mujoco_ros2_control/issues/256>)
* MuJoCo free joints state publisher plugin (#247 <https://github.com/ros-controls/mujoco_ros2_control/issues/247>)
* Add service to set the free joint body state (#233 <https://github.com/ros-controls/mujoco_ros2_control/issues/233>)
* Contributors: Sai Kishor Kothakota, Sebastian Castro
```

## mujoco_ros2_control_plugins

```
* Add a pre-step callback to the simulation (#282 <https://github.com/ros-controls/mujoco_ros2_control/issues/282>)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Add base twist plugin for commanding the mobile base (#254 <https://github.com/ros-controls/mujoco_ros2_control/issues/254>)
* [doc] Fix undefined label errors (#260 <https://github.com/ros-controls/mujoco_ros2_control/issues/260>)
* Add missing documentation (#249 <https://github.com/ros-controls/mujoco_ros2_control/issues/249>)
* Add missing dependencies (#250 <https://github.com/ros-controls/mujoco_ros2_control/issues/250>)
* [CI] Fix dependency declarations for bloom (#226 <https://github.com/ros-controls/mujoco_ros2_control/issues/226>)
* MuJoCo free joints state publisher plugin (#247 <https://github.com/ros-controls/mujoco_ros2_control/issues/247>)
* Fix CameraPlugin default frame name to be consistent with docs.  (#242 <https://github.com/ros-controls/mujoco_ros2_control/issues/242>)
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Make CI tests more robust (#239 <https://github.com/ros-controls/mujoco_ros2_control/issues/239>)
* Fix links in interface docs, use auto label generator like the upstream (#238 <https://github.com/ros-controls/mujoco_ros2_control/issues/238>)
* Add Plugin for the 3D Lidar Extension (#207 <https://github.com/ros-controls/mujoco_ros2_control/issues/207>)
* Fix plugin export so that downstream plugins don't fail (#215 <https://github.com/ros-controls/mujoco_ros2_control/issues/215>)
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
* Support polling, streaming, and disabled cameras in camera plugin (#217 <https://github.com/ros-controls/mujoco_ros2_control/issues/217>)
* Refactor Rangefinder base Lidar as a Plugin (#214 <https://github.com/ros-controls/mujoco_ros2_control/issues/214>)
* Refactor RGB-D Cameras to a Plugin (#211 <https://github.com/ros-controls/mujoco_ros2_control/issues/211>)
  Co-authored-by: Erik Holum <mailto:erik.holum@nasa.gov>
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Migrate documentation to rst format for control.ros.org (#188 <https://github.com/ros-controls/mujoco_ros2_control/issues/188>)
* Contributors: Christian Rauch, Erik Holum, Nathan Dunkelberger, Sai Kishor Kothakota, Sebastian Castro, msavchen-nasa, pang-yann
```
