### PR TITLE
wuji_description: 2026.8.19-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11687,6 +11687,15 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: lyrical
     status: maintained
+  wuji_description:
+    release:
+      packages:
+      - wuji_hand2_beta1_description
+      - wuji_hand2_beta2_description
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/wuji-technology/wuji-description-release.git
+      version: 2026.8.19-1
   xacro:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11837,6 +11837,11 @@ repositories:
         release: release/lyrical/{package}/{version}
       url: https://github.com/wuji-technology/wuji-description-release.git
       version: 2026.8.19-1
+    source:
+      type: git
+      url: https://github.com/wuji-technology/wuji-description.git
+      version: main
+    status: developed
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wuji_description` to `2026.8.19-1`:

- upstream repository: https://github.com/wuji-technology/wuji-description.git
- release repository: https://github.com/wuji-technology/wuji-description-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
