### PR TITLE
libbno055_linux: 1.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5322,7 +5322,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/lazytatzv/libbno055_linux-release.git
-      version: 1.7.2-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/lazytatzv/libbno055-linux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libbno055_linux` to `1.9.0-1`:

- upstream repository: https://github.com/lazytatzv/libbno055-linux.git
- release repository: https://github.com/lazytatzv/libbno055_linux-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.2-1`
