### PR TITLE
tf2_2d: 1.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10145,7 +10145,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tf2_2d-release.git
-      version: 1.6.1-2
+      version: 1.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `1.6.2-1`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/ros2-gbp/tf2_2d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.6.1-2`

## tf2_2d

```
* Fix Cmake warnings related to Boost cmake files (#13 <https://github.com/locusrobotics/tf2_2d/issues/13>)
* Contributors: Stephen Williams
```
