### PR TITLE
Add FastSwarmSim ROS 2 packages for Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3562,6 +3562,28 @@ repositories:
       url: https://github.com/ros-event-camera/frequency_cam.git
       version: release
     status: developed
+
+  fss_bringup:
+    doc:
+      type: git
+      url: https://github.com/shupx/FastSwarmSim.git
+      version: main
+    release:
+      packages:
+      - fss_bringup
+      - fss_px4_sim
+      - fss_sensing
+      - fss_time
+      - fss_time_interfaces
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/shupx/FastSwarmSim-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/shupx/FastSwarmSim.git
+      version: main
+    status: maintained
   fusioncore:
     doc:
       type: git


### PR DESCRIPTION
## Package updates

Add the following FastSwarmSim ROS 2 packages to the Humble distribution index:

- fss_bringup
- fss_px4_sim
- fss_sensing
- fss_time
- fss_time_interfaces

Repository:
https://github.com/shupx/FastSwarmSim

Release tag:
v0.1.1

This PR intentionally changes only `humble/distribution.yaml`.
