### PR TITLE
Revert "behaviortree_cpp_v4: 4.9.1-1 in 'kilted/distribution.yaml' [bloom]"

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -896,7 +896,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.9.1-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
All downstream builds are regressed, so I'm rolling this package back to unblock the Kilted sync.

FYI @facontidavide

This reverts #52466.