### PR TITLE
fuse: 1.1.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3484,7 +3484,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.1.5-1
+      version: 1.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.1.6-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.5-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

```
* Fix edge condition on Boost fix versions. (#425 <https://github.com/locusrobotics/fuse/issues/425>)
  Boost Version 1.90 is affected by the any_range bug. Make sure that version is included in the fix.
* Workaround for a bug in Boost 1.90 any_range included in Ubuntu Resolute (#424 <https://github.com/locusrobotics/fuse/issues/424>)
  Boost versions 1.88 - 1.90 are missing a header include for any_range.hpp or any_iterator.hpp. The workaround is to include the missing header before including one of the affect headers.
* Contributors: Stephen Williams
```

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

- No changes

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

- No changes

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

- No changes
