### PR TITLE
marti_common: 3.9.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4376,14 +4376,13 @@ repositories:
       - swri_image_util
       - swri_math_util
       - swri_opencv_util
-      - swri_roscpp
       - swri_route_util
       - swri_serial_util
       - swri_transform_util
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.9.0-1
+      version: 3.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.9.1-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.9.0-1`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Removing unnecessary dependency on pkg-config (#797 <https://github.com/swri-robotics/marti_common/issues/797>)
* Handling self-intersecting polygons (#793 <https://github.com/swri-robotics/marti_common/issues/793>)
* Contributors: David Anthony
```

## swri_image_util

```
* Removing unnecessary dependency on pkg-config (#797 <https://github.com/swri-robotics/marti_common/issues/797>)
* Adding replace colors node for ROS 2 (#796 <https://github.com/swri-robotics/marti_common/issues/796>)
* Adding more robust package version compatibility checks (#795 <https://github.com/swri-robotics/marti_common/issues/795>)
* Lyrical Update (#790 <https://github.com/swri-robotics/marti_common/issues/790>)
  * Deprecating swri_roscpp
  * Removing deprecated calls
  * Updating for new image transport interface
  * Updating filenames for deprecated files
  * Updating references to deprecated files
  * Updating to spin executor
  * Updating to use new ament_idnex_cpp function
  * Removing pre-lyrical releases from testing
  * Adding dual compatibility with older APIs
* Contributors: David Anthony
```

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_route_util

```
* Handling improper normalization in projectOntoRoute when a point is past the end of the route (#794 <https://github.com/swri-robotics/marti_common/issues/794>)
* Contributors: David Anthony
```

## swri_serial_util

- No changes

## swri_transform_util

```
* Updating node interface APIs to new format for recent ROS 2 distros (#799 <https://github.com/swri-robotics/marti_common/issues/799>)
* Adding more robust package version compatibility checks (#795 <https://github.com/swri-robotics/marti_common/issues/795>)
* Forward declaring geographic lib pointer so we do not need to export it via CMake (#792 <https://github.com/swri-robotics/marti_common/issues/792>)
* Lyrical Update (#790 <https://github.com/swri-robotics/marti_common/issues/790>)
  * Deprecating swri_roscpp
  * Removing deprecated calls
  * Updating for new image transport interface
  * Updating filenames for deprecated files
  * Updating references to deprecated files
  * Updating to spin executor
  * Updating to use new ament_idnex_cpp function
  * Removing pre-lyrical releases from testing
  * Adding dual compatibility with older APIs
* Contributors: David Anthony
```
