### PR TITLE
unbag: 1.3.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11122,11 +11122,15 @@ repositories:
       version: main
     status: maintained
   unbag:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/ros2_unbag.git
+      version: main
     release:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/unbag-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/ros2_unbag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `unbag` to `1.3.1-1`:

- upstream repository: https://github.com/ika-rwth-aachen/ros2_unbag.git
- release repository: https://github.com/ros2-gbp/unbag-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.0-1`
