### PR TITLE
unbag: 1.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10765,6 +10765,22 @@ repositories:
       url: https://github.com/flynneva/udp_msgs.git
       version: main
     status: maintained
+  unbag:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/ros2_unbag.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/unbag-release.git
+      version: 1.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ika-rwth-aachen/ros2_unbag.git
+      version: main
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `unbag` to `1.3.1-1`:

- upstream repository: https://github.com/ika-rwth-aachen/ros2_unbag.git
- release repository: https://github.com/ros2-gbp/unbag-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
