### PR TITLE
Add moodycamel concurrentqueue rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -754,18 +754,6 @@ comedi:
   debian: [libcomedi-dev]
   nixos: [comedilib]
   ubuntu: [libcomedi-dev]
-libconcurrentqueue-dev:
-  arch: [concurrentqueue]
-  debian: [libconcurrentqueue-dev]
-  fedora: [moodycamel-concurrentqueue-devel]
-  freebsd: [concurrentqueue]
-  osx:
-    homebrew:
-      packages: [concurrentqueue]
-  rhel: [moodycamel-concurrentqueue-devel]
-  ubuntu:
-    '*': [libconcurrentqueue-dev]
-    focal: null
 coreutils:
   arch: [coreutils]
   debian: [coreutils]
@@ -3582,6 +3570,18 @@ libcoin80-dev:
   ubuntu:
     '*': [libcoin-dev]
     bionic: [libcoin80-dev]
+libconcurrentqueue-dev:
+  arch: [concurrentqueue]
+  debian: [libconcurrentqueue-dev]
+  fedora: [moodycamel-concurrentqueue-devel]
+  freebsd: [concurrentqueue]
+  osx:
+    homebrew:
+      packages: [concurrentqueue]
+  rhel: [moodycamel-concurrentqueue-devel]
+  ubuntu:
+    '*': [libconcurrentqueue-dev]
+    focal: null
 libconfig++-dev:
   arch: [libconfig]
   debian: [libconfig++-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -754,6 +754,18 @@ comedi:
   debian: [libcomedi-dev]
   nixos: [comedilib]
   ubuntu: [libcomedi-dev]
+concurrentqueue:
+  arch: [concurrentqueue]
+  debian: [libconcurrentqueue-dev]
+  fedora: [moodycamel-concurrentqueue-devel]
+  freebsd: [concurrentqueue]
+  osx:
+    homebrew:
+      packages: [concurrentqueue]
+  rhel: [moodycamel-concurrentqueue-devel]
+  ubuntu:
+    '*': [libconcurrentqueue-dev]
+    focal: null
 coreutils:
   arch: [coreutils]
   debian: [coreutils]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -754,7 +754,7 @@ comedi:
   debian: [libcomedi-dev]
   nixos: [comedilib]
   ubuntu: [libcomedi-dev]
-concurrentqueue:
+libconcurrentqueue-dev:
   arch: [concurrentqueue]
   debian: [libconcurrentqueue-dev]
   fedora: [moodycamel-concurrentqueue-devel]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`concurrentqueue`

## Package Upstream Source:

https://github.com/cameron314/concurrentqueue

## Purpose of using this:

Popular lock-free, blocking and non-blocking queue C++ implementation. Very useful in concurrent heavy and time sensitive applications.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: 
  - https://packages.debian.org/search?searchon=names&keywords=concurrentqueue
- Ubuntu:
  - https://packages.ubuntu.com/search?lang=cs&keywords=libconcurrentqueue-dev&searchon=names
- Fedora:
  - https://packages.fedoraproject.org/pkgs/moodycamel-concurrentqueue/moodycamel-concurrentqueue-devel/
- Arch:
  - https://archlinux.org/packages/extra/any/concurrentqueue/
- Gentoo:
  - NOT AVAILABLE
- macOS:
  - https://formulae.brew.sh/formula/concurrentqueue#default
- Alpine: 
  - NOT AVAILABLE
- NixOS/nixpkgs: 
  - NOT AVAILABLE
- openSUSE:
  - NOT AVAILABLE
- rhel: 
  - https://pkgs.org/search/?q=concurrentqueue
