### PR TITLE
pal_pro_gripper: 1.12.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7945,7 +7945,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_pro_gripper-release.git
-      version: 1.12.5-1
+      version: 1.12.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_pro_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_pro_gripper` to `1.12.6-1`:

- upstream repository: https://github.com/pal-robotics/pal_pro_gripper.git
- release repository: https://github.com/ros2-gbp/pal_pro_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.12.5-1`

## pal_pro_gripper

- No changes

## pal_pro_gripper_bringup

- No changes

## pal_pro_gripper_controller_configuration

- No changes

## pal_pro_gripper_description

```
* Merge branch 'opo/mujoco-sim' into 'humble-devel'
  mujoco sim changes
  See merge request robots/pal_pro_gripper!47
* fix argument
* put initial state just for gazebo
* adapt transmission for the mujoco ros2 control
* add sim_type arg for the ros2-control tags
* parametrize common args in gripper_limits.xacro
* move mj tags to gripper.urdf.xacro
* add check for the value of the sim_type arg
* remove extra arguments from show_args
* fixed multiplier arg
* fixed param
* added sim_type for transmission
* added sym_type parameter in transmission
* loading transmission also for sim in mujoco
* added args in show.launch
* fixed default sim_type
* added motor actuator
* fixed transmission actuator name for mujoco
* removed extra if
* align to the new mujoco_ros2_control
* Contributors: Ortisa Poci, Sai Kishor Kothakota
```

## pal_pro_gripper_simulation

- No changes

## pal_pro_gripper_wrapper

- No changes
