### PR TITLE
launch_pal: 0.22.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5172,7 +5172,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_pal-release.git
-      version: 0.22.0-1
+      version: 0.22.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.22.1-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/ros2-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.22.0-1`

## launch_pal

```
* Add test to verify the behaviour
* Fix arg_utils to parse launch arguments in lyrical
* change default mj_initial_pose to home
* Contributors: Ortisa Poci, Sai Kishor Kothakota
```
