### PR TITLE
tiago_dual_simulation: 4.13.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12836,6 +12836,14 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_simulation.git
       version: humble-devel
+    release:
+      packages:
+      - tiago_dual_gazebo
+      - tiago_dual_simulation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/tiago_dual_simulation-release.git
+      version: 4.13.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_dual_simulation` to `4.13.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_dual_simulation.git
- release repository: https://github.com/ros2-gbp/tiago_dual_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## tiago_dual_gazebo

```
* start apps using localization manager
* Contributors: antoniobrandi
```

## tiago_dual_simulation

- No changes
