### PR TITLE
mujoco_vendor: 0.0.9-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6739,7 +6739,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_vendor-release.git
-      version: 0.0.9-1
+      version: 0.0.9-2
     source:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_vendor` to `0.0.9-2`:

- upstream repository: https://github.com/pal-robotics/mujoco_vendor.git
- release repository: https://github.com/ros2-gbp/mujoco_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.9-1`

## mujoco_vendor

```
* Export simulate, lodepng, and path variables for downstream packages (#10 <https://github.com/pal-robotics/mujoco_vendor/issues/10>)
* Add support for the AMENT_VENDOR_POLICY variable to support unvendoring (#9 <https://github.com/pal-robotics/mujoco_vendor/issues/9>)
* Contributors: Erik Holum, Silvio Traversaro
```
