### PR TITLE
kangaroo_simulation: 2.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4804,6 +4804,14 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/kangaroo_simulation.git
       version: humble-devel
+    release:
+      packages:
+      - kangaroo_mujoco
+      - kangaroo_simulation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/kangaroo_simulation-release.git
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/kangaroo_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kangaroo_simulation` to `2.7.0-1`:

- upstream repository: https://github.com/pal-robotics/kangaroo_simulation.git
- release repository: https://github.com/ros2-gbp/kangaroo_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## kangaroo_mujoco

```
* Merge branch 'add/compatibility/latest_release' into 'humble-devel'
  Shutdown nodes when mujoco simulation fails to launch
  See merge request robots/kangaroo_simulation!29
* Exit and shutdown nodes when mujoco_ros2_control fail to launch
* Add velocity PIDs to avoid failing the simulation
* Merge branch 'feat/rough_terrain_4dof' into 'humble-devel'
  Adding rough terrain world
  See merge request robots/kangaroo_simulation!28
* Using the rough terrain world in 4dof config
* Adding rough terrain world
  Almost identical to the mjlab terrain curriculum but smaller
* Using new world structure
  Per world scene controlled via the world_name argument
* Moving world definition to a separate folder
* Merge branch 'feat/include_subs' into 'humble-devel'
  Function to substitute include tags
  See merge request robots/kangaroo_simulation!26
* More generic xml structure
  The publisher loads a scene, wich is environment + robotm making easier
  to work with different environments
* Function to substitute include tags
  Replaces recursively any present include tags in an mjcf string for
  their actual content, cleaning their mujoco tags
* Contributors: Sai Kishor Kothakota, Óscar Martínez
```

## kangaroo_simulation

- No changes
