### PR TITLE
metavision_driver: 3.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4650,7 +4650,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 3.0.0-3
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `3.0.2-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-3`

## metavision_driver

```
* revert rosidl dependencies
* Contributors: Bernd Pfrommer
```
