### PR TITLE
laser_filters: 2.0.10-5 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5027,7 +5027,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.9-1
+      version: 2.0.10-5
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.10-5`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.9-1`

## laser_filters

```
* Optional wrapping of angles in AngularBoundsFilter
* New added LaserScanBinningFilter: places measurements into fixed number of bins.
* Set hardware id in diagnostic messages
* Contributors: Anthony Goeckner, Griffin Tabor, Tatsuro Sakaguchi, K Herbstzuber
```
