### PR TITLE
rmw_int2dds: 0.1.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10000,6 +10000,15 @@ repositories:
       type: git
       url: https://github.com/IntellectusCorp/rmw_int2dds.git
       version: humble
+    release:
+      packages:
+      - int2dds_ffi_vendor
+      - rmw_int2dds_cpp
+      - rmw_int2dds_validation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/IntellectusCorp/rmw_int2dds-release.git
+      version: 0.1.0-3
     source:
       type: git
       url: https://github.com/IntellectusCorp/rmw_int2dds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_int2dds` to `0.1.0-3`:

- upstream repository: https://github.com/IntellectusCorp/rmw_int2dds.git
- release repository: https://github.com/IntellectusCorp/rmw_int2dds-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## int2dds_ffi_vendor

```
* Move the package into the ``rmw_int2dds`` repository, next to
  ``rmw_int2dds_cpp``, so the two are released in lockstep. The prebuilt FFI
  tarballs are still published on the ``int2dds_ffi_vendor`` release page and
  are downloaded and sha256-verified at CMake configure time, unchanged.
* Contributors: Intellectus Corp.
```

## rmw_int2dds_cpp

```
* Fix participant/context lifecycle: delete contained entities before the
  participant, release the participant when the last node is destroyed,
  recreate context DDS resources on node creation, and release all context
  resources on init failure.
* Apply requested QoS in services/clients; resolve BEST_AVAILABLE and
  SYSTEM_DEFAULT in the service actual QoS; apply deadline/liveliness.
* Wire localhost-only discovery into SPDP.
* Reject STRICTLY_REQUIRED unique network flow endpoints; restore content-filter
  field codes; set error messages on unsupported API stubs; ignore only
  same-node local publications; randomize the GID process field.
* Batch ``take_sequence`` into a single serialized take.
* Move development test executables into ``test/``; align QUALITY_DECLARATION
  and README test status with the current state.
* Decide ``rmw_wait`` readiness before attaching to the wait set, so a call that
  finds work already pending skips the attach/wait/detach round trip. Guard
  conditions join the pre-wait scan through a non-destructive peek, and a
  zero-timeout poll no longer attaches at all. Saturated single-subscription
  throughput roughly doubles.
* Add ``test_rmw_wait_guards``, the first automated test registered with CTest:
  guard condition readiness, trigger consumption, timeout handling and wake-up
  from another thread, all without a DDS participant.
* Move the ``int2dds_ffi_vendor`` package into this repository. Building from
  source no longer needs a second clone, and the dependency is declared without
  a version range because the two packages are now released in lockstep; the
  prebuilt FFI version stays pinned in one place, ``INT2DDS_FFI_VERSION`` in
  ``int2dds_ffi_vendor/CMakeLists.txt``.
* Cache wait set attachments across ``rmw_wait`` calls, rebuild them by delta
  instead of a full reset, and skip the event status mask update when it is
  already set.
* Harden the persistent attachment cache against teardown and concurrency:
  detach attachments before removing the wait set from the registry, keep the
  registry valid during static destruction, make the registry insert
  exception-safe, clean caches and delete the status condition on the detached
  service/client destroy path, clean caches before freeing the context guard,
  re-flag an entity for re-attach when its reader or event status condition is
  momentarily null, and close the destroy-vs-cache race in the attachments.
* Serialize the concurrent service RPC paths under a multi-threaded executor:
  guard the response writer in ``rmw_send_response`` and the request/response
  readers in ``rmw_take_request`` / ``rmw_take_response`` per entity, fixing an
  intermittent service round-trip hang.
* Build the graph cache from SEDP endpoint-discovery push callbacks, remove
  graph entities on the dispose signal instead of on absence from a snapshot,
  and identify the local participant by its own key.
* Default ``INT2DDS_DATA_FRAG_SIZE`` to 1344 and ``INT2DDS_MAX_MESSAGE_SIZE`` to
  13440 in ``rmw_init``, and document the loopback discovery env vars in the
  usage table.
* Drop key/key_len from serialized write calls and bulk-copy fixed-width
  primitive arrays in the CDR codec.
* Contributors: Intellectus Corp.
```
