### PR TITLE
pal_urdf_utils: 2.9.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6222,6 +6222,17 @@ repositories:
       url: https://github.com/pal-robotics/pal_statistics.git
       version: humble-devel
     status: maintained
+  pal_urdf_utils:
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/pal_urdf_utils-release.git
+      version: 2.9.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_urdf_utils.git
+      version: humble-devel
+    status: maintained
   pangolin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_urdf_utils` to `2.9.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_urdf_utils.git
- release repository: https://github.com/ros2-gbp/pal_urdf_utils-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## pal_urdf_utils

```
* Merge branch 'add/ft_sensor/mujoco_tags' into 'humble-devel'
  Add mujoco specific tags to the ft_sensor ros2_control config
  See merge request robots/pal_urdf_utils!45
* Add mujoco specific tags to the ft_sensor ros2_control config
* Contributors: Sai Kishor Kothakota
```
