### PR TITLE
rmw_cyclonedds: 4.1.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7903,7 +7903,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 4.1.4-3
+      version: 4.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `4.1.5-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.1.4-3`

## rmw_cyclonedds_cpp

```
* Fix subscription graph cleanup on destruction (#594 <https://github.com/ros2/rmw_cyclonedds/issues/594>) (#598 <https://github.com/ros2/rmw_cyclonedds/issues/598>)
* Downgrade 'Failed to parse type hash' log from WARN to DEBUG (#591 <https://github.com/ros2/rmw_cyclonedds/issues/591>) (#595 <https://github.com/ros2/rmw_cyclonedds/issues/595>)
* Contributors: mergify[bot]
```
