### PR TITLE
rmw_cyclonedds: 2.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9500,7 +9500,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `2.2.4-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.3-1`

## rmw_cyclonedds_cpp

```
* Downgrade 'Failed to parse type hash' log from WARN to DEBUG (#591 <https://github.com/ros2/rmw_cyclonedds/issues/591>) (#597 <https://github.com/ros2/rmw_cyclonedds/issues/597>)
* improve MessageTypeSupport performance. (#562 <https://github.com/ros2/rmw_cyclonedds/issues/562>) (#570 <https://github.com/ros2/rmw_cyclonedds/issues/570>)
* Performance improvements in serialization (#553 <https://github.com/ros2/rmw_cyclonedds/issues/553>) (#554 <https://github.com/ros2/rmw_cyclonedds/issues/554>)
* Contributors: mergify[bot]
```
