### PR TITLE
mola: 3.2.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4791,7 +4791,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 3.0.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `3.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## mola

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* Merge pull request #198 <https://github.com/MOLAorg/mola/issues/198> from Zeal-Robotics/fix/bridge_ros2-tf-buffer-staleness
  fix(bridge_ros2): keep the TF buffer current under bridge executor load
* fix(bridge_ros2): give the TF listener its own spin thread
  The listener was constructed with spin_thread=false, against tf2's own default,
  on the grounds that the bridge already spins rosNode_ and a second spinner would
  be redundant. That holds only while the bridge executor keeps up with /tf, and
  makes buffer freshness a function of everything else the node is handling --
  sensor callbacks, timers, map publishing. When it does not keep up, the failure
  is silent: lookups still succeed, they just answer from a buffer that is behind,
  and the resulting poses look plausible.
  With spin_thread=true the /tf and /tf_static subscriptions move to a callback
  group and executor the listener owns, so ingestion is independent of the bridge
  executor's load.
  No new sharing is introduced. The buffer is already read from other threads --
  publishLocalizationTf() from the localization source's thread, transform_tree()
  from whichever module calls it -- and tf2::BufferCore serialises readers and
  writers on a single mutex. The listener's group is created with
  automatically_add_to_executor_with_node=false, so add_node() does not adopt it
  and no second executor can dispatch those subscriptions. Its destructor cancels
  and joins its thread, and it is declared after tf_buffer_ and rosNode_, so that
  happens while both are still alive.
* fix(bridge_ros2): drain the ROS queues instead of one message per topic
  The ROS thread polls spin_some() on a 10 ms sleep. That loop replaced a
  blocking rclcpp::spin() so the destructor could stop the thread via
  shouldExit_, and the sleep was only ever there to keep the flag poll from
  busy-waiting. But spin_some() collects the ready set once and executes each
  ready entity at most once per call, so the pair caps every subscription at
  roughly one message per 10 ms and puts a 10 ms floor under handling anything.
  Any topic arriving faster than ~100 Hz therefore keeps its subscription queue
  permanently full, and every message the node sees is stale by the whole queue
  depth. /tf is the worst case: it aggregates every broadcaster on the graph,
  so on a robot publishing a few hundred transforms/s the listener's
  KeepLast(100) queue leaves the TF buffer several hundred ms behind. The visible
  symptom is REP-105 composition falling back to the stale odom transform with
  "extrapolation into the future" while the odom broadcaster is publishing on
  time and a normally-spun listener on the same graph reads it as current. A
  200 Hz IMU on the same node loses half its samples the same way.
  spin_once(timeout) blocks until there is work while still bounding how long
  shouldExit_ goes unchecked, and spin_all() then drains whatever else is
  ready. Both are needed: spin_some() and spin_all() each call
  wait_for_work(0ms), so spin_all() alone returns immediately when idle and
  would busy-wait. With work pending spin_once() returns at once, so no
  iteration sleeps while a queue is non-empty.
  Cost is that the two bounds stack: worst case for observing shouldExit_ goes
  from 10 ms to 20 ms.
  Measured with two TF listeners on the same /tf, one per spin strategy:
  draining fully leaves the buffer 12.6 ms behind the broadcaster, taking one
  message per 10 ms tick leaves it 358 ms behind.
  A blocking spin() cancelled via executor.cancel() would remove the poll
  loop altogether and is the better end state, but cancel() racing the
  spinning.exchange(true) in spin() means the destructor has to retry until
  the thread joins. That is left as a separate change.
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco, Robin Van Cauwenbergh
```

## mola_demos

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_lidar_bin_dataset

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Merge pull request #192 <https://github.com/MOLAorg/mola/issues/192> from MOLAorg/feat/map-frame-gauge-change
  Support re-expressing estimator and pose-list state in a new frame
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* mola_kernel: declare transform_frame() last; test SearchablePoseList frame change
  Appending the new optional virtual only grows the vtable, whereas the
  previous mid-list position shifted the slot index of the three virtuals
  after it, breaking any prebuilt NavStateFilter plugin. A note asks that
  future optional virtuals also go at the end.
  Adds regression coverage for SearchablePoseList::transform_left_multiply()
  in both storage modes: that the kd-tree follows the transformed poses
  (verified to fail if the spatial index is left stale), that the empty and
  identity cases are no-ops, and that the id-keyed lookup survives.
* Merge branch 'develop' into feat/map-frame-gauge-change
* Support re-expressing estimator and pose-list state in a new frame
  Adds the two pieces a one-off gauge change of the map frame needs, so that
  leveling the frame once gravity is known does not have to throw state away:
  - NavStateFilter::transform_frame(), an optional virtual returning false by
  default, so existing estimators are unaffected and a caller that gets false
  falls back to reset(). Guarded by a feature macro for downstream detection.
  - SearchablePoseList::transform_left_multiply(), so keyframe-density
  bookkeeping moves with the frame instead of being invalidated by it.
  Both are pure left-multiplications, p -> b + p. Note that relative motion,
  and hence any velocity expressed in the vehicle's own frame, is invariant
  under this and must NOT be rotated.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Merge pull request #195 <https://github.com/MOLAorg/mola/issues/195> from MOLAorg/feat/cov2cov-ambiguity-gating
  mola_metric_maps: adopt mp2p_icp::MatchingDistanceProfile in nn_search_cov2cov
* Merge branch 'develop' into feat/cov2cov-ambiguity-gating
* mola_metric_maps: remove the ambiguity gate from nn_search_cov2cov()
  Companion to the removal in mp2p_icp`#89 <https://github.com/MOLAorg/mola/issues/89>`_: firstToSecondDistanceMin/
  firstToSecondMinRange were not yet justified by results. Drop the
  gate logic (and the k=2 / radius-inflated query it required) from
  IncrementalPointCloud and KeyframePointCloudMap's exact and
  approximate-cov paths, the flat compat stand-in, and the
  corresponding test coverage, keeping the range-adaptive matching
  distance.
* mola_metric_maps: build against mp2p_icp releases without MatchingDistanceProfile
  rosdep resolves mp2p_icp to the last released binary package in every CI job, so
  this tree has to compile against an mp2p_icp that predates
  MatchingDistanceProfile.
  Adds MatchingDistanceProfileCompat.h, which either aliases the real type or, when
  the header is absent, supplies a flat-only stand-in with the same small surface.
  The search implementations are written against that alias and so stay free of
  preprocessor branches; only the public overload, and the tests that exercise the
  ambiguity gate, are guarded by MP2P_ICP_HAS_MATCHING_DISTANCE_PROFILE.
  Both map classes now implement the flat-threshold overload (still the pure
  virtual upstream) as a forwarder into a shared private nn_search_cov2cov_impl(),
  so the two public entry points cannot drift apart.
* mola_metric_maps: adopt mp2p_icp::MatchingDistanceProfile in nn_search_cov2cov
  Follows the mp2p_icp interface change: nn_search_cov2cov() now receives a
  MatchingDistanceProfile instead of a flat float search distance. Implemented in
  IncrementalPointCloud and in both KeyframePointCloudMap paths (exact and
  approximate-cov).
  The flat, ungated default keeps a dedicated fast path in all three: no
  per-point range is computed and the KD-tree query stays k=1, so the previous
  behavior is reproduced exactly and at the same cost.
  When the ambiguity test is active for a query point, the search radius is
  inflated by the ratio, so any runner-up able to disqualify the winner is
  guaranteed to lie inside it, and the best two candidates are kept. In the
  approximate-cov path the runner-up may live in a different keyframe than the
  winner, so the best two are folded across all active keyframes rather than per
  keyframe.
  Range is measured in the query point's own untransformed (sensor) frame.
  Tests added for the ambiguity gate in both map classes.
* Merge pull request #193 <https://github.com/MOLAorg/mola/issues/193> from MOLAorg/fix/incremental-map-pairing-order
  Give IncrementalPointCloud::nn_search_cov2cov() a canonical pairing order
* Give IncrementalPointCloud::nn_search_cov2cov() a canonical pairing order
  The same defect fixed for KeyframePointCloudMap in bfe6cb2e, which did not
  cover this map class: the parallel path accumulates correspondences into a
  tbb::enumerable_thread_specific and merges it by iteration, whose order is
  unspecified. The permutation is not cosmetic, it reaches the solver, which
  sums the normal equations over the pairing list in order.
  This class needs a stronger fix than the keyframe map did, because here the
  *sequential* path was not canonical either. The live local points come from
  snapshotLiveIndices(), a depth-first walk of the k-d tree, so they arrive in
  tree-topology order rather than in slot order. Tombstones and rebuilds change
  that shape, so with async_rebuild enabled the pairing order varied between
  runs even single-threaded. The sort is therefore applied to the shared
  intermediate match list, before the pairings are assembled, which pins both
  paths to the same order and makes the result independent of the tree shape a
  rebuild happened to leave behind. Two sibling call sites in this file already
  sort that snapshot for the same reason.
  Sorting the intermediate list rather than the output pairings also keeps the
  comparison on an 8-byte key instead of a full pairing, and gives the assembly
  pass ascending access into the coordinate and covariance buffers.
  Each local point yields at most one match, so its slot is a unique key and the
  resulting order is total.
  test_pairing_order_is_canonical asserts ascending local_idx and identical order
  across repeated calls, over a cloud with tombstones so tree order really does
  diverge from slot order, and large enough that TBB splits the range across
  workers. It fails without this change with "Pairings are not in canonical
  (ascending local_idx) order".
* silent a gcc warning (safe)
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

```
* Merge pull request #192 <https://github.com/MOLAorg/mola/issues/192> from MOLAorg/feat/map-frame-gauge-change
  Support re-expressing estimator and pose-list state in a new frame
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* mola_kernel: declare transform_frame() last; test SearchablePoseList frame change
  Appending the new optional virtual only grows the vtable, whereas the
  previous mid-list position shifted the slot index of the three virtuals
  after it, breaking any prebuilt NavStateFilter plugin. A note asks that
  future optional virtuals also go at the end.
  Adds regression coverage for SearchablePoseList::transform_left_multiply()
  in both storage modes: that the kd-tree follows the transformed poses
  (verified to fail if the spatial index is left stale), that the empty and
  identity cases are no-ops, and that the id-keyed lookup survives.
* Merge branch 'develop' into feat/map-frame-gauge-change
* Support re-expressing estimator and pose-list state in a new frame
  Adds the two pieces a one-off gauge change of the map frame needs, so that
  leveling the frame once gravity is known does not have to throw state away:
  - NavStateFilter::transform_frame(), an optional virtual returning false by
  default, so existing estimators are unaffected and a caller that gets false
  falls back to reset(). Guarded by a feature macro for downstream detection.
  - SearchablePoseList::transform_left_multiply(), so keyframe-density
  bookkeeping moves with the frame instead of being invalidated by it.
  Both are pure left-multiplications, p -> b + p. Note that relative motion,
  and hence any velocity expressed in the vehicle's own frame, is invariant
  under this and must NOT be rotated.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Remove stray COLCON_IGNORE from mola_viz, mola_viz_imgui
  Both were accidentally swept into 2c5735f5 ("declare transform_frame()
  last..."), unrelated to that commit's actual content. With colcon no
  longer building them from source, any package depending on mola_viz
  (e.g. mola_mapper's exec_depend) falls back to the stale public
  ros-<distro>-mola-viz release, which pulls in a matching stale
  ros-<distro>-mola-kernel via apt -- and since /opt/ros/<distro>/include
  is searched before the workspace install prefix, that stale
  mola_kernel silently shadows the freshly-built one, breaking any
  translation unit that needs a recent mola_kernel API
  (ChildLoggerName/child_loggers()).
* Merge pull request #192 <https://github.com/MOLAorg/mola/issues/192> from MOLAorg/feat/map-frame-gauge-change
  Support re-expressing estimator and pose-list state in a new frame
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* mola_kernel: declare transform_frame() last; test SearchablePoseList frame change
  Appending the new optional virtual only grows the vtable, whereas the
  previous mid-list position shifted the slot index of the three virtuals
  after it, breaking any prebuilt NavStateFilter plugin. A note asks that
  future optional virtuals also go at the end.
  Adds regression coverage for SearchablePoseList::transform_left_multiply()
  in both storage modes: that the kd-tree follows the transformed poses
  (verified to fail if the spatial index is left stale), that the empty and
  identity cases are no-ops, and that the id-keyed lookup survives.
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz_imgui

```
* Fix mola_viz_imgui GUI rendering nothing depending on link order
  MolaVizImGui::DEFAULT_WINDOW_NAME was copy-initialized from
  MolaVizImGuiCore::DEFAULT_WINDOW_NAME, a std::string global in another
  translation unit, whose initialization order is unspecified. When the
  module TU is initialized first, the copy ends up empty, the host window
  gets registered under "" and every VizInterface call (which defaults to
  the literal "main" from VizInterface.h) misses, so the window opens but
  stays empty, with "unknown parentWindow 'main'" warnings.
  Both string objects are now initialized from a new constexpr literal,
  DEFAULT_WINDOW_NAME_LITERAL, so they no longer depend on each other.
* Remove stray COLCON_IGNORE from mola_viz, mola_viz_imgui
  Both were accidentally swept into 2c5735f5 ("declare transform_frame()
  last..."), unrelated to that commit's actual content. With colcon no
  longer building them from source, any package depending on mola_viz
  (e.g. mola_mapper's exec_depend) falls back to the stale public
  ros-<distro>-mola-viz release, which pulls in a matching stale
  ros-<distro>-mola-kernel via apt -- and since /opt/ros/<distro>/include
  is searched before the workspace install prefix, that stale
  mola_kernel silently shadows the freshly-built one, breaking any
  translation unit that needs a recent mola_kernel API
  (ChildLoggerName/child_loggers()).
* Merge pull request #192 <https://github.com/MOLAorg/mola/issues/192> from MOLAorg/feat/map-frame-gauge-change
  Support re-expressing estimator and pose-list state in a new frame
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* mola_kernel: declare transform_frame() last; test SearchablePoseList frame change
  Appending the new optional virtual only grows the vtable, whereas the
  previous mid-list position shifted the slot index of the three virtuals
  after it, breaking any prebuilt NavStateFilter plugin. A note asks that
  future optional virtuals also go at the end.
  Adds regression coverage for SearchablePoseList::transform_left_multiply()
  in both storage modes: that the kd-tree follows the transformed poses
  (verified to fail if the spatial index is left stale), that the empty and
  identity cases are no-ops, and that the id-keyed lookup survives.
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Merge remote-tracking branch 'origin/feat/map-frame-gauge-change' into feat/map-frame-gauge-change
* Merge branch 'develop' into feat/map-frame-gauge-change
* Contributors: Jose Luis Blanco-Claraco
```
