### PR TITLE
crazyswarm2: 1.0.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1525,7 +1525,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/crazyswarm2-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/IMRCLab/crazyswarm2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crazyswarm2` to `1.0.7-1`:

- upstream repository: https://github.com/IMRCLab/crazyswarm2.git
- release repository: https://github.com/ros2-gbp/crazyswarm2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.6-1`

## crazyflie

```
* Add rclpy to package.xml to fix build farm errors
* Contributors: Kimberly McGuire
```

## crazyflie_description

- No changes

## crazyflie_examples

- No changes

## crazyflie_interfaces

- No changes

## crazyflie_py

- No changes

## crazyflie_server_cpp

- No changes

## crazyflie_server_py

- No changes

## crazyflie_sim

- No changes
