### PR TITLE
[rosdep] Added lua5.3-dev.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8119,6 +8119,13 @@ lua5.2-dev:
   openembedded: [lua@meta-oe]
   rhel: [lua-devel]
   ubuntu: [liblua5.2-dev]
+lua5.3-dev:
+  alpine: [lua5.3-dev]
+  arch: [lua53]
+  debian: [liblua5.3-dev]
+  gentoo: ['dev-lang/lua:5.3']
+  nixos: [lua5_3]
+  ubuntu: [liblua5.3-dev]
 lz4:
   alpine: [lz4-dev]
   arch: [lz4]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

lua5.3-dev

## Package Upstream Source:

https://www.lua.org/  (source package: lua5.3)

## Purpose of using this:

Addingg lua5.3-dev

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/liblua5.3-dev
  - liblua5.3-dev
- Ubuntu: https://packages.ubuntu.com/liblua5.3-dev
  - liblua5.3-dev
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://archlinux.org/packages/extra/x86_64/lua53/
  - lua53
- Gentoo: https://packages.gentoo.org/packages/dev-lang/lua
  - dev-lang/lua:5.3
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages?name=lua5.3-dev
  - lua5.3-dev
- NixOS/nixpkgs: https://search.nixos.org/packages?query=lua5_3
  - lua5_3
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available