### PR TITLE
ros_industrial_cmake_boilerplate: 0.7.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10355,11 +10355,20 @@ repositories:
       version: rolling
     status: developed
   ros_industrial_cmake_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+      version: master
     release:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
-      version: 0.5.4-3
+      version: 0.7.5-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+      version: master
+    status: maintained
   ros_snapd_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.7.5-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.4-3`

## ros_industrial_cmake_boilerplate

```
* package.xml: fix the license string to correct SPDX format
* Contributors: Jan Vermaete
```
