### PR TITLE
ros_industrial_cmake_boilerplate: 0.7.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10743,11 +10743,20 @@ repositories:
       version: humble
     status: developed
   ros_industrial_cmake_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+      version: master
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
-      version: 0.4.0-1
+      version: 0.7.5-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+      version: master
+    status: maintained
   ros_snapd_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.7.5-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-1`

## ros_industrial_cmake_boilerplate

```
* package.xml: fix the license string to correct SPDX format
* Contributors: Jan Vermaete
```
