### PR TITLE
jrl_cmakemodules: 2.3.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3783,7 +3783,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
-      version: 2.2.4-1
+      version: 2.3.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jrl_cmakemodules` to `2.3.0-1`:

- upstream repository: https://github.com/jrl-umi3218/jrl-cmakemodules.git
- release repository: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.4-1`
