### PR TITLE
boost_plugin_loader: 0.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1043,10 +1043,20 @@ repositories:
       version: master
     status: developed
   boost_plugin_loader:
+    doc:
+      type: git
+      url: https://github.com/tesseract-robotics/boost_plugin_loader.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/tesseract-robotics/boost_plugin_loader.git
       version: main
+    status: developed
   boost_sml_vendor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1050,7 +1050,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/tesseract-robotics-release/boost_plugin_loader-release.git
+      url: https://github.com/ros2-gbp/boost_plugin_loader-release.git
       version: 0.4.4-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_plugin_loader` to `0.4.4-1`:

- upstream repository: https://github.com/tesseract-robotics/boost_plugin_loader.git
- release repository: https://github.com/ros2-gbp/boost_plugin_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## boost_plugin_loader

```
* Add BUILD_EXAMPLES option
* Dropped CI support for Ubuntu 20.04; added CI support for Ubuntu 26.04 (#40 <https://github.com/tesseract-robotics/boost_plugin_loader/issues/40>)
  * Dropped CI support for Ubuntu 20.04; added CI support for Ubuntu 26.04
  * Bump colcon-action to v14
* Contributors: Michael Ripperger, Rick van Essen
```
