### PR TITLE
foxglove_sdk_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2490,7 +2490,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_sdk_vendor-release.git
-      version: 0.2.0-3
+      version: 0.3.0-1
     source:
       type: git
       url: https://gitlab.com/jlack/foxglove_sdk_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_sdk_vendor` to `0.3.0-1`:

- upstream repository: https://gitlab.com/jlack/foxglove_sdk_vendor.git
- release repository: https://github.com/ros2-gbp/foxglove_sdk_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.0-3`
