### PR TITLE
trimble_driver_ros: index into lyrical

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10841,6 +10841,12 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
+  trimble_driver:
+    source:
+      type: git
+      url: https://github.com/trimble-oss/trimble_driver_ros.git
+      version: lyrical
+    status: developed
   tsid:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

trimble_driver

## Package Upstream Source:

https://github.com/trimble-oss/trimble_driver_ros.git

## Purpose of using this:

Trimble customers can use this package to read data from various GNSS Receivers and INS products.

Its already indexed in jazzy.

Distro packaging links:
N/A