### PR TITLE
roboplan: 0.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9645,7 +9645,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/roboplan-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/open-planning/roboplan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboplan` to `0.6.1-1`:

- upstream repository: https://github.com/open-planning/roboplan.git
- release repository: https://github.com/ros2-gbp/roboplan-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.0-1`

## roboplan

```
* Rename filters target to roboplan_filters (#284 <https://github.com/open-planning/roboplan/issues/284>)
* Depend on typing_extensions via rosdep (#283 <https://github.com/open-planning/roboplan/issues/283>)
* Contributors: Matteo Villani, Sebastian Castro
```

## roboplan_cartesian_planning

```
* Depend on typing_extensions via rosdep (#283 <https://github.com/open-planning/roboplan/issues/283>)
* Contributors: Sebastian Castro
```

## roboplan_example_models

```
* Depend on typing_extensions via rosdep (#283 <https://github.com/open-planning/roboplan/issues/283>)
* Contributors: Sebastian Castro
```

## roboplan_examples

```
* Optionally brake to target in OInK acceleration limit (#290 <https://github.com/open-planning/roboplan/issues/290>)
* Fix OInK position barrier Jacobian (#288 <https://github.com/open-planning/roboplan/issues/288>)
* Fix keyboard teleop example (#289 <https://github.com/open-planning/roboplan/issues/289>)
* Contributors: Sebastian Castro
```

## roboplan_oink

```
* Optionally brake to target in OInK acceleration limit (#290 <https://github.com/open-planning/roboplan/issues/290>)
* Fix OInK position barrier Jacobian (#288 <https://github.com/open-planning/roboplan/issues/288>)
* fix missing braces warnings (#282 <https://github.com/open-planning/roboplan/issues/282>)
* Depend on typing_extensions via rosdep (#283 <https://github.com/open-planning/roboplan/issues/283>)
* Contributors: Matteo Villani, Sebastian Castro
```

## roboplan_rrt

```
* Depend on typing_extensions via rosdep (#283 <https://github.com/open-planning/roboplan/issues/283>)
* Contributors: Sebastian Castro
```

## roboplan_simple_ik

```
* Depend on typing_extensions via rosdep (#283 <https://github.com/open-planning/roboplan/issues/283>)
* Contributors: Sebastian Castro
```

## roboplan_toppra

```
* fix missing braces warnings (#282 <https://github.com/open-planning/roboplan/issues/282>)
* Depend on typing_extensions via rosdep (#283 <https://github.com/open-planning/roboplan/issues/283>)
* Contributors: Matteo Villani, Sebastian Castro
```
