### PR TITLE
roboplan_ros: 0.6.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8098,7 +8098,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/roboplan_ros-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/open-planning/roboplan-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboplan_ros` to `0.6.1-1`:

- upstream repository: https://github.com/open-planning/roboplan-ros.git
- release repository: https://github.com/ros2-gbp/roboplan_ros-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.0-1`

## roboplan_ros_cpp

```
* Depend on typing_extensions via rosdep (#62 <https://github.com/open-planning/roboplan-ros/issues/62>)
* Contributors: Sebastian Castro
```

## roboplan_ros_examples

- No changes

## roboplan_ros_franka

- No changes

## roboplan_ros_py

- No changes

## roboplan_ros_visualization

```
* Depend on typing_extensions via rosdep (#62 <https://github.com/open-planning/roboplan-ros/issues/62>)
* Contributors: Sebastian Castro
```
