### PR TITLE
mavros: 2.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4403,7 +4403,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.15.0-1
+      version: 2.15.1-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.15.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.0-1`

## libmavconn

```
* libmavconn: fix serial baudrate parsing above uint16
  url_parse_host hardcoded a uint16 port limit and error label, which
  rejected serial baudrates above 65535 (e.g. 921600) with a misleading
  'invalid port value' error. Make the value range and field name
  configurable and allow baudrate to use the full int range.
  Adds a regression test covering a high valid baudrate and invalid
  zero/non-numeric baudrates.
  Fix #2265 <https://github.com/mavlink/mavros/issues/2265>
* Merge pull request #2260 <https://github.com/mavlink/mavros/issues/2260> from mavlink/fix-deprecations
  Fix deprecations
* libmavconn: fix deprecated literal operator whitespace
* libmavconn: avoid -Wformat-security in format() with no args
* Contributors: Vladimir Ermakov
```

## mavros

```
* mavros: fix duplicated namespace in launch files
  Fix #2262 <https://github.com/mavlink/mavros/issues/2262> by defaulting the launch namespace to empty, since plugin
  subnodes now properly inherit the UAS namespace.
* Merge pull request #2260 <https://github.com/mavlink/mavros/issues/2260> from mavlink/fix-deprecations
  Fix deprecations
* mavros: fix deprecated subscription callback signatures
  rclcpp deprecates callbacks taking non-const std::shared_ptr<MessageT>. Convert topic subscription callbacks to MessageT::ConstSharedPtr, and the Mavlink router/UAS bus to MessageT::UniquePtr (matching the zero-copy make_unique publisher).
* mavros: add StateQoS and use it for state publications
  Add a named StateQoS profile (QoS(10).transient_local()) and use it in sys_status and home_position instead of an inline state_qos. Regenerate the plugin docs.
* docs: restructure node docs and refresh links
  Move mavros README content into docs/ (connection URLs, frames, nodes, troubleshooting), reduce package READMEs to GitHub overviews, add mermaid diagrams, and refresh docs.ros.org references to Lyrical.
* Contributors: Vladimir Ermakov
```

## mavros_examples

- No changes

## mavros_extras

```
* extras: fix mount diagnostic clock source
* extras: fix HIL_GPS over-scaling and expose id/yaw (fix #2090 <https://github.com/mavlink/mavros/issues/2090>)
* Merge pull request #2260 <https://github.com/mavlink/mavros/issues/2260> from mavlink/fix-deprecations
  Fix deprecations
* mavros: fix deprecated subscription callback signatures
  rclcpp deprecates callbacks taking non-const std::shared_ptr<MessageT>. Convert topic subscription callbacks to MessageT::ConstSharedPtr, and the Mavlink router/UAS bus to MessageT::UniquePtr (matching the zero-copy make_unique publisher).
* docs: restructure node docs and refresh links
  Move mavros README content into docs/ (connection URLs, frames, nodes, troubleshooting), reduce package READMEs to GitHub overviews, add mermaid diagrams, and refresh docs.ros.org references to Lyrical.
* Contributors: Vladimir Ermakov
```

## mavros_msgs

```
* extras: fix HIL_GPS over-scaling and expose id/yaw (fix #2090 <https://github.com/mavlink/mavros/issues/2090>)
* Contributors: Vladimir Ermakov
```
