### PR TITLE
mapviz: 4.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4494,7 +4494,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `4.0.3-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.2-1`

## mapviz

```
* Updating to use new tf2_ros API (#907 <https://github.com/swri-robotics/mapviz/issues/907>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

- No changes
