### PR TITLE
trimble_driver: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12745,6 +12745,19 @@ repositories:
       version: main
     status: developed
   trimble_driver:
+    doc:
+      type: git
+      url: https://github.com/trimble-oss/trimble_driver_ros.git
+      version: jazzy
+    release:
+      packages:
+      - trimble_driver
+      - trimble_gsof_msgs
+      - trimble_interfaces
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/trimble_driver_ros-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/trimble-oss/trimble_driver_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trimble_driver` to `0.1.1-1`:

- upstream repository: https://github.com/trimble-oss/trimble_driver_ros.git
- release repository: https://github.com/ros2-gbp/trimble_driver_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## trimble_driver

```
* fix: Add buffer check to StreamPageParser
  can cause segfault in certain cases
* feat: jazzy: Port #33 <https://github.com/trimble-oss/trimble_driver_ros/issues/33> and #36 <https://github.com/trimble-oss/trimble_driver_ros/issues/36> (#37 <https://github.com/trimble-oss/trimble_driver_ros/issues/37>)
  * fix(gsof_client): Remove unique_ptr wrapper on std::thread (#33 <https://github.com/trimble-oss/trimble_driver_ros/issues/33>)
  Easy fix to prevent segfault when the thread is not created
  * refactor: make unit tests use synthetic data instead of pcaps (#36 <https://github.com/trimble-oss/trimble_driver_ros/issues/36>)
  The ROS buildfarm doesn't support git lfs and thus all the unit tests fail. Made the main tests use synthetic data but also kept the old unit tests using recorded pcaps. These old tests can still be run and will run in github actions CI.
* fix: avoid pointer arithmetic
  This triggered CWE-468
* style: clang-format
* refactor: rename gsof_msgs to trimble_gsof_msgs
* fix: rename folder to match new package name
* Contributors: Andre Nguyen
```

## trimble_gsof_msgs

```
* refactor: rename gsof_msgs to trimble_gsof_msgs
* Contributors: Andre Nguyen
```

## trimble_interfaces

```
* feat: follow SPDX identifier for license
* Initial public release
* Contributors: Andre Nguyen
```
