### PR TITLE
trimble_driver: 0.2.0-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10850,6 +10850,25 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
+  trimble_driver:
+    doc:
+      type: git
+      url: https://github.com/trimble-oss/trimble_driver_ros.git
+      version: lyrical
+    release:
+      packages:
+      - trimble_driver
+      - trimble_gsof_msgs
+      - trimble_interfaces
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/trimble_driver_ros-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/trimble-oss/trimble_driver_ros.git
+      version: lyrical
+    status: developed
   tsid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `trimble_driver` to `0.2.0-2`:

- upstream repository: https://github.com/trimble-oss/trimble_driver_ros.git
- release repository: https://github.com/ros2-gbp/trimble_driver_ros-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## trimble_driver

```
* ci: update to ros lyrical (#41 <https://github.com/trimble-oss/trimble_driver_ros/issues/41>)
* feat: client callback error handler (#39 <https://github.com/trimble-oss/trimble_driver_ros/issues/39>)
* fix: avoid pointer arithmetic for codeql (#38 <https://github.com/trimble-oss/trimble_driver_ros/issues/38>)
* refactor: make unit tests use synthetic data instead of pcaps (#36 <https://github.com/trimble-oss/trimble_driver_ros/issues/36>)
  The ROS buildfarm doesn't support git lfs and thus all the unit tests fail. Made the main tests use synthetic data but also kept the old unit tests using recorded pcaps. These old tests can still be run and will run in github actions CI.
* fix(gsof_client): Remove unique_ptr wrapper on std::thread (#33 <https://github.com/trimble-oss/trimble_driver_ros/issues/33>)
  Easy fix to prevent segfault when the thread is not created
* fix: avoid pointer arithmetic
  This triggered CWE-468
* style: clang-format
* refactor: rename gsof_msgs to trimble_gsof_msgs
* fix: rename folder to match new package name
* Contributors: Andre Nguyen
```

## trimble_gsof_msgs

```
* refactor: rename gsof_msgs to trimble_gsof_msgs
* Contributors: Andre Nguyen
```

## trimble_interfaces

```
* feat: follow SPDX identifier for license
* Initial public release
* Contributors: Andre Nguyen, André Nguyen
```
