### PR TITLE
ouster-ros: 0.15.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7833,7 +7833,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
-      version: 0.14.2-1
+      version: 0.15.1-1
     source:
       type: git
       url: https://github.com/ouster-lidar/ouster-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster-ros` to `0.15.1-1`:

- upstream repository: https://github.com/ouster-lidar/ouster-ros.git
- release repository: https://github.com/ros2-gbp/ouster-ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.14.2-1`
