### PR TITLE
ouster-ros: 0.15.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6060,7 +6060,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
-      version: 0.14.2-1
+      version: 0.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster-ros` to `0.15.1-1`:

- upstream repository: https://github.com/ouster-lidar/ouster-ros.git
- release repository: https://github.com/ros2-gbp/ouster-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.14.2-1`
