### PR TITLE
cras_ros_utils: 4.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1480,7 +1480,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cras_ros_utils-release.git
-      version: 3.0.2-2
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1480,7 +1480,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cras_ros_utils-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `4.0.1-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils.git
- release repository: https://github.com/ros2-gbp/cras_ros_utils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-2`

## cras_bag_tools

```
* package.xml: set license to valid SPDX string (#13)
* Contributors: Jan Vermaete
```

## cras_cpp_common

```
* package.xml: set license to valid SPDX string (#13)
* Renamed some .h files to .hpp (breaking change!)
* Applied new naming style. (breaking change!)
* Updated code style.
* time_utils: Completed the who-to-who conversion matrix in convertTime and convertDuration. It's possible this introduced subtle behavior changes, but it should be generally safe.
* filter_utils: Added FilterBase.
* param_utils: Added ParamHelper.
* string_utils: Added to_string() for ParameterValue and friends.
* Added cras::is_optional trait
* Export cras_defaults target in cras_cpp_common that defines basic compiler features used by CRAS packages.
* math_utils: Added min/max to RunningStats, enabled tests.
* Fixed include directories for exported targets.
* Fixed shared libraries.
* cloud, tf2_sensor_msgs: Converted to ROS 2.
* Ported urdf_utils to ROS 2.
* Contributors: Martin Pecka, Jan Vermaete
```

## cras_lint

```
* fix: Added missing licenses.
* Updated to new code style that is closer to Google Code Style (breaking change!)
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* package.xml: set license to valid SPDX string (#13)
* fix: Properly export dependencies.
* Applied new naming style. (breaking change!)
* Updated code style.
* Contributors: Martin Pecka, Jan Vermaete
```
