### PR TITLE
compass: 4.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1854,7 +1854,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.2-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `4.0.1-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://github.com/ros2-gbp/compass-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-1`

## compass_conversions

```
* fix: Updated license strings to SPDX identifiers
* feat!: Install include directories to subdirectory to support workspace overlays.
* feat!: Applied new naming scheme
* feat: Updated code style.
* Contributors: Martin Pecka
```

## compass_interfaces

```
* fix: Updated license strings to SPDX identifiers
* fix: Properly export cras_cpp_common dependency.
* feat!: Install include directories to subdirectory to support workspace overlays.
* feat!: Applied new naming scheme.
* feat: Updated code style.
* Contributors: Martin Pecka
```

## magnetic_model

```
* fix: Updated license strings to SPDX identifiers
* feat!: Install include directories to subdirectory to support workspace overlays.
* feat!: Applied new naming scheme.
* feat: Updated coding style.
* Contributors: Martin Pecka
```

## magnetometer_compass

```
* fix: Updated license strings to SPDX identifiers
* fix: Fixed build on Lyrical and Rolling.
* fix: Adapt to latest changes in cras_cpp_common.
* feat!: Install include directories to subdirectory to support workspace overlays.
* feat!: Applied new naming scheme
* feat: Updated code style.
* Contributors: Martin Pecka
```

## magnetometer_pipeline

```
* fix: Updated license strings to SPDX identifiers
* feat!: Install include directories to subdirectory to support workspace overlays.
* feat!: Applied new naming scheme.
* feat: Updated code style.
* Contributors: Martin Pecka
```