### PR TITLE
compass: 4.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1342,7 +1342,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.2-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `4.0.1-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://github.com/ros2-gbp/compass-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-1`

## compass_conversions

```
* fix: Updated license strings to SPDX identifiers
* Contributors: Martin Pecka
```

## compass_interfaces

```
* fix: Updated license strings to SPDX identifiers
* Contributors: Martin Pecka
```

## magnetic_model

```
* fix: Updated license strings to SPDX identifiers
* Contributors: Martin Pecka
```

## magnetometer_compass

```
* fix: Updated license strings to SPDX identifiers
* Contributors: Martin Pecka
```

## magnetometer_pipeline

```
* fix: Updated license strings to SPDX identifiers
* Contributors: Martin Pecka
```
