### PR TITLE
ros2_pulse: 0.4.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10479,6 +10479,21 @@ repositories:
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
       version: humble-devel
     status: developed
+  ros2_pulse:
+    doc:
+      type: git
+      url: https://github.com/TanayK07/ros2_pulse.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/TanayK07/ros2_pulse-release.git
+      version: 0.4.1-2
+    source:
+      type: git
+      url: https://github.com/TanayK07/ros2_pulse.git
+      version: main
+    status: developed
   ros2_robotiq_gripper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_pulse` to `0.4.1-2`:

- upstream repo: https://github.com/TanayK07/ros2_pulse.git
- release repo: https://github.com/TanayK07/ros2_pulse-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## ros2_pulse

Low-overhead ROS 2 probe for per-topic message rate and active-node liveness, covering inter-process and intra-process traffic on stock binaries (an `LD_PRELOAD` shim over the tracetools instrumentation layer; no rebuild, no privileges, no DDS traffic). First release. Apache-2.0. CI on `ros:humble`: https://github.com/TanayK07/ros2_pulse/actions. Docs: https://tanayk07.github.io/ros2_pulse/
