### PR TITLE
novatel_gps_driver: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5502,7 +5502,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.3.0-1
+      version: 5.0.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `5.0.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.3.0-1`

## novatel_gps_driver

```
* rolling compatibility updates (#131 <https://github.com/swri-robotics/novatel_gps_driver/issues/131>)
  * rolling compatibility updates
  * Updating for API changes to ament_index_cpp
* Contributors: David Anthony
```

## novatel_gps_msgs

```
* rolling compatibility updates (#131 <https://github.com/swri-robotics/novatel_gps_driver/issues/131>)
  * rolling compatibility updates
  * Updating for API changes to ament_index_cpp
* Contributors: David Anthony
```
