### PR TITLE
novatel_gps_driver: 4.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5702,7 +5702,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.3.0-1
+      version: 4.3.1-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.3.1-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.3.0-1`

## novatel_gps_driver

```
* Add deprecation warning (#135 <https://github.com/swri-robotics/novatel_gps_driver/issues/135>)
* Removing swri_roscpp and API updates (#134 <https://github.com/swri-robotics/novatel_gps_driver/issues/134>)
* Contributors: David Anthony
```

## novatel_gps_msgs

- No changes
