### PR TITLE
elite_robots: 1.0.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2825,7 +2825,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_robots` to `1.0.0-2`:

- upstream repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver.git
- release repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## elite_robots

```
* First public release.
* Added a single installation point for the Elite Robots ROS 2 packages.
* Contributors: Ivan
```

## elite_robots_calibration

```
* First public release of the Elite Robots factory calibration correction tool.
* Renamed the package to ``elite_robots_calibration``.
* Contributors: Yan
```

## elite_robots_controllers

```
* First public release of the Elite Robots ROS 2 controllers.
* Added speed-scaled trajectory, GPIO, freedrive, and speed-scaling controllers.
* Renamed the package to ``elite_robots_controllers``.
* Contributors: Yan
```

## elite_robots_dashboard_msgs

```
* First public release of the Elite Robots dashboard service interfaces.
* Renamed the package to ``elite_robots_dashboard_msgs``.
* Contributors: Yan
```

## elite_robots_driver

```
* First public release of the Elite Robots CS ROS 2 driver.
* Added ros2_control hardware, dashboard, primary, and reverse interfaces.
* Added launch files and controller configurations for Elite CS robots.
* Renamed the package to ``elite_robots_driver``.
* Contributors: Yan
```

## elite_robots_moveit_config

```
* First public release of the Elite Robots MoveIt 2 configuration.
* Added planning, kinematics, controller, SRDF, RViz, and launch configurations.
* Renamed the package and MoveIt launch files.
* Contributors: Yan
```

## elite_robots_msgs

```
* First public release of the Elite Robots message and service interfaces.
* Renamed the package to ``elite_robots_msgs``.
* Contributors: Yan
```
