### PR TITLE
elite_robots: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2825,7 +2825,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_robots` to `1.0.1-1`:

- upstream repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver.git
- release repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## elite_robots

```
* Synchronize the metapackage version for the repository-wide dependency fix release.
* Contributors: Ivan
```

## elite_robots_calibration

```
* Declare the Elite CS Series SDK dependency required by the calibration tool.
* Declare the ament index and launch dependencies used by the package.
* Contributors: Ivan
```

## elite_robots_controllers

```
* Declare direct controller build and runtime dependencies.
* Correct the exported dependency list.
* Contributors: Ivan
```

## elite_robots_dashboard_msgs

```
* Synchronize the package version for the repository-wide dependency fix release.
* Contributors: Ivan
```

## elite_robots_driver

```
* Declare the Elite CS Series SDK dependency.
* Declare geometry messages, standard messages, realtime tools, and example runtime dependencies explicitly.
* Contributors: Ivan
```

## elite_robots_moveit_config

```
* Declare the Python ament index and YAML runtime dependencies.
* Contributors: Ivan
```

## elite_robots_msgs

```
* Declare the geometry messages dependency used by ``SetPayload``.
* Contributors: Ivan
```
