### PR TITLE
urdf_test: 2.1.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10958,6 +10958,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: ros2
     status: maintained
+  urdf_test:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/urdf_test.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf_test-release.git
+      version: 2.1.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/urdf_test.git
+      version: humble-devel
+    status: maintained
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `2.1.2-1`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/ros2-gbp/urdf_test-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## urdf_test

```
* Remove unused setup.py
* Bump cmake version to 3.10
* Contributors: Noel Jimenez
```
