### PR TITLE
rqt_bag: 2.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8993,7 +8993,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.0.3-2
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.0.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.3-2`

## rqt_bag

- No changes

## rqt_bag_plugins

- No changes
