### PR TITLE
add canary github repo to rolling distribution

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -11446,5 +11446,11 @@ repositories:
       url: https://github.com/autowarefoundation/zmqpp_vendor.git
       version: main
     status: developed
+  canary:
+    source:
+      type: git
+      url: https://github.com/knmcguire/canary
+      version: main
+    status: developed
 type: distribution
 version: 2

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1077,6 +1077,12 @@ repositories:
       url: https://github.com/christianrauch/camera_ros.git
       version: main
     status: developed
+  canary:
+    source:
+      type: git
+      url: https://github.com/knmcguire/canary
+      version: main
+    status: developed
   canboat_vendor:
     source:
       type: git
@@ -11444,12 +11450,6 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/zmqpp_vendor.git
-      version: main
-    status: developed
-  canary:
-    source:
-      type: git
-      url: https://github.com/knmcguire/canary
       version: main
     status: developed
 type: distribution

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1080,7 +1080,7 @@ repositories:
   canary:
     source:
       type: git
-      url: https://github.com/knmcguire/canary
+      url: https://github.com/knmcguire/canary.git
       version: main
     status: developed
   canboat_vendor:


### PR DESCRIPTION
<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Canary

# The source is here:

https://github.com/knmcguire/canary

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
