### PR TITLE
Update nodl repo URL, remove ament_nodl entry

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -449,17 +449,6 @@ repositories:
       url: https://github.com/ament/ament_lint.git
       version: humble
     status: developed
-  ament_nodl:
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/ament_nodl-release.git
-      version: 0.1.0-4
-    source:
-      type: git
-      url: https://github.com/ubuntu-robotics/ament_nodl.git
-      version: master
-    status: developed
   ament_package:
     doc:
       type: git
@@ -7291,8 +7280,8 @@ repositories:
   nodl:
     doc:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      url: https://github.com/ros-tooling/nodl.git
+      version: main
     release:
       packages:
       - nodl_python
@@ -7303,8 +7292,8 @@ repositories:
       version: 0.3.1-3
     source:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      url: https://github.com/ros-tooling/nodl.git
+      version: main
     status: developed
   nodl_to_policy:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -415,17 +415,6 @@ repositories:
       url: https://github.com/ament/ament_lint.git
       version: jazzy
     status: developed
-  ament_nodl:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/ament_nodl-release.git
-      version: 0.1.0-7
-    source:
-      type: git
-      url: https://github.com/ubuntu-robotics/ament_nodl.git
-      version: master
-    status: developed
   ament_package:
     doc:
       type: git
@@ -7082,8 +7071,8 @@ repositories:
   nodl:
     doc:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      url: https://github.com/ros-tooling/nodl.git
+      version: main
     release:
       packages:
       - nodl_python
@@ -7094,8 +7083,8 @@ repositories:
       version: 0.3.1-5
     source:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      url: https://github.com/ros-tooling/nodl.git
+      version: main
     status: developed
   nodl_to_policy:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -345,17 +345,6 @@ repositories:
       url: https://github.com/ament/ament_lint.git
       version: kilted
     status: developed
-  ament_nodl:
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/ament_nodl-release.git
-      version: 0.1.0-7
-    source:
-      type: git
-      url: https://github.com/ubuntu-robotics/ament_nodl.git
-      version: master
-    status: developed
   ament_package:
     doc:
       type: git
@@ -5644,8 +5633,8 @@ repositories:
   nodl:
     doc:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      url: https://github.com/ros-tooling/nodl.git
+      version: main
     release:
       packages:
       - nodl_python
@@ -5656,8 +5645,8 @@ repositories:
       version: 0.3.1-5
     source:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      url: https://github.com/ros-tooling/nodl.git
+      version: main
     status: developed
   nodl_to_policy:
     doc:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -382,17 +382,6 @@ repositories:
       url: https://github.com/ament/ament_lint.git
       version: lyrical
     status: developed
-  ament_nodl:
-    release:
-      tags:
-        release: release/lyrical/{package}/{version}
-      url: https://github.com/ros2-gbp/ament_nodl-release.git
-      version: 0.1.0-8
-    source:
-      type: git
-      url: https://github.com/ubuntu-robotics/ament_nodl.git
-      version: master
-    status: developed
   ament_package:
     doc:
       type: git
@@ -5774,7 +5763,7 @@ repositories:
   nodl:
     doc:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
+      url: https://github.com/ros-tooling/nodl.git
       version: main
     release:
       packages:
@@ -5786,7 +5775,7 @@ repositories:
       version: 0.3.1-6
     source:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
+      url: https://github.com/ros-tooling/nodl.git
       version: main
     status: developed
   nodl_to_policy:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -348,17 +348,6 @@ repositories:
       url: https://github.com/ament/ament_lint.git
       version: rolling
     status: developed
-  ament_nodl:
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ament_nodl-release.git
-      version: 0.1.0-7
-    source:
-      type: git
-      url: https://github.com/ubuntu-robotics/ament_nodl.git
-      version: master
-    status: developed
   ament_package:
     doc:
       type: git
@@ -5459,7 +5448,7 @@ repositories:
   nodl:
     doc:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
+      url: https://github.com/ros-tooling/nodl.git
       version: main
     release:
       packages:
@@ -5471,7 +5460,7 @@ repositories:
       version: 0.3.1-5
     source:
       type: git
-      url: https://github.com/ubuntu-robotics/nodl.git
+      url: https://github.com/ros-tooling/nodl.git
       version: main
     status: developed
   nodl_to_policy:


### PR DESCRIPTION
# Please Update This Package in the rosdistro index

1. Update `nodl` repository URL in `source:` and `doc:`. If you follow the original https://github.com/ubuntu-robotics/nodl.git - you'll see by the redirect that this was a repository transfer of ownership, not a fork. It lives in the `ros-tooling` org now.
2. Do not touch the `release:` entries yet. This is preparation, not a new release yet.
3. Remove `ament_nodl` index entry. The package was consolidated into the `nodl` repository. Follow https://github.com/ubuntu-robotics/ament_nodl and you'll see it was also ownership transferred to `ros-tooling` org. There it is now archived and directs you to https://github.com/ros-tooling/nodl/, where the [source for ament_nodl](https://github.com/ros-tooling/nodl/tree/main/ament_nodl) now lives.

Distributions (all live distros):
- humble
- kilted
- jazzy
- lyrical
- rolling

Closes https://github.com/ros-tooling/nodl/issues/123

# The source is here:

https://github.com/ros-tooling/nodl

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
