### PR TITLE
robstride_ros2: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9777,6 +9777,16 @@ repositories:
       version: ros
     status: maintained
   robstride_ros2:
+    release:
+      packages:
+      - robstride_driver
+      - robstride_examples
+      - robstride_ros2
+      - robstride_ros2_control
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/robstride_ros2-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/s2015-turtle/robstride_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robstride_ros2` to `0.1.0-1`:

- upstream repository: https://github.com/s2015-turtle/robstride_ros2.git
- release repository: https://github.com/ros2-gbp/robstride_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## robstride_driver

```
* Add the RobStride private-CAN protocol, topic transport, motor lifecycle,
  feedback monitoring, and Run-mode recovery library.
* Clamp position, velocity, and effort commands to per-joint operational
  limits before CAN encoding.
* Contributors: Yamato.K
```

## robstride_examples

```
* Add launch, controller configuration, and RS/EduLite actuator profiles.
* Expose optional position, velocity, and effort command limits in every motor
  profile macro.
* Require explicit ``kp`` and ``kd`` arguments for every motor-profile macro.
* Contributors: Yamato.K
```

## robstride_ros2

```
* Keep ``robstride_ros2`` as the aggregate installation entry point while the
  implementation is split into driver, ros2_control, and example packages.
* Move development headers to ``robstride_ros2_control`` and example resources
  to ``robstride_examples`` while preserving the existing plugin identifier.
* Contributors: Yamato.K
```

## robstride_ros2_control

```
* Add a ros2_control SystemInterface adapter backed by ``robstride_driver``.
* Support position, velocity, and effort command-mode switching per joint.
* Parse and validate optional ROS joint-coordinate command limits separately
  from the CAN encoding ranges.
* Reject non-finite joint values, invalid watchdog values, and blank CAN topic
  names during hardware configuration.
* Contributors: Yamato.K
```
