### PR TITLE
Add wato_monorepo as source-only entry (jazzy)

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -13818,6 +13818,12 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git
       version: ros2
     status: maintained
+  wato_monorepo:
+    source:
+      type: git
+      url: https://github.com/WATonomous/wato_monorepo.git
+      version: main
+    status: developed
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Jazzy

# The source is here:

https://github.com/WATonomous/wato_monorepo.git

Note: wato_monorepo is a monorepo containing many unrelated packages (~78).
This entry is only for the 4 packages listed below; the rest are intentionally
excluded from release via a Bloom ignore list.

This repository provides the following ROS 2 packages (to be released later via Bloom):

- `eidos`
- `eidos_msgs`
- `eidos_transform`
- `eidos_tools`

Eidos is a plugin-based LiDAR-Inertial SLAM and localization system. Its plugin
architecture lets you swap sensors and add constraints (factor plugins,
relocalization plugins, visualization plugins) without modifying core code,
using GTSAM's ISAM2 to maintain the underlying factor graph. This is a
source-only entry ahead of a future release PR.

# Checks
- [x] All packages have a declared license in the package.xml
- [x] This repository has a LICENSE file
- [x] This package is expected to build on the submitted rosdistro