### PR TITLE
robstride_ros2: 0.1.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8178,6 +8178,16 @@ repositories:
       version: ros
     status: maintained
   robstride_ros2:
+    release:
+      packages:
+      - robstride_driver
+      - robstride_examples
+      - robstride_ros2
+      - robstride_ros2_control
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/robstride_ros2-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/s2015-turtle/robstride_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robstride_ros2` to `0.1.1-1`:

- upstream repository: https://github.com/s2015-turtle/robstride_ros2.git
- release repository: https://github.com/ros2-gbp/robstride_ros2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## robstride_driver

```
* Synchronize the package version for the multi-package compatibility release.
* Contributors: Yamato.K
```

## robstride_examples

```
* Use ``forward_command_controller`` for position, velocity, and effort
  examples across all supported ROS distributions.
* Contributors: Yamato.K
```

## robstride_ros2

```
* Update the example-controller dependency set for all supported ROS
  distributions.
* Contributors: Yamato.K
```

## robstride_ros2_control

```
* Synchronize the package version for the multi-package compatibility release.
* Contributors: Yamato.K
```
