### PR TITLE
depthai-ros: 3.4.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1726,6 +1726,19 @@ repositories:
       type: git
       url: https://github.com/luxonis/depthai-ros.git
       version: develop
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_descriptions
+      - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
+      - depthai_ros_msgs
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.4.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## depthai_bridge

```
* Fixes for ROS lyrical
* Add OAK-4-PRO-W to tf mappings
* Bringing to parity with develop-old
```

## depthai_examples

```
* Bringing to parity with develop-old
```

## depthai_ros_msgs

```
* Fixes for ROS lyrical
```
