### PR TITLE
rmw_int2dds: 0.1.0-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8045,6 +8045,26 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: lyrical
     status: developed
+  rmw_int2dds:
+    doc:
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: lyrical
+    release:
+      packages:
+      - int2dds_ffi_vendor
+      - rmw_int2dds_cpp
+      - rmw_int2dds_validation
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_int2dds-release.git
+      version: 0.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: lyrical
+    status: developed
   rmw_zenoh:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_int2dds` to `0.1.0-2`:

- upstream repository: https://github.com/IntellectusCorp/rmw_int2dds.git
- release repository: https://github.com/ros2-gbp/rmw_int2dds-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
