### PR TITLE
Index FastSwarmSim source repository for Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3586,6 +3586,12 @@ repositories:
       url: https://github.com/ros-event-camera/frequency_cam.git
       version: release
     status: developed
+  fastswarmsim:
+    source:
+      type: git
+      url: https://github.com/shupx/FastSwarmSim.git
+      version: main
+    status: maintained
   fusioncore:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3139,12 +3139,6 @@ repositories:
       version: 1.0.x
     status: maintained
   fastrtps:
-  fastswarmsim:
-    source:
-      type: git
-      url: https://github.com/shupx/FastSwarmSim.git
-      version: main
-    status: maintained
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3156,6 +3150,12 @@ repositories:
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.6.x
+    status: maintained
+  fastswarmsim:
+    source:
+      type: git
+      url: https://github.com/shupx/FastSwarmSim.git
+      version: main
     status: maintained
   feetech_ros2_driver:
     release:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3139,6 +3139,12 @@ repositories:
       version: 1.0.x
     status: maintained
   fastrtps:
+  fastswarmsim:
+    source:
+      type: git
+      url: https://github.com/shupx/FastSwarmSim.git
+      version: main
+    status: maintained
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3586,12 +3592,6 @@ repositories:
       url: https://github.com/ros-event-camera/frequency_cam.git
       version: release
     status: developed
-  fastswarmsim:
-    source:
-      type: git
-      url: https://github.com/shupx/FastSwarmSim.git
-      version: main
-    status: maintained
   fusioncore:
     doc:
       type: git


### PR DESCRIPTION
## Source repository indexing

Add the FastSwarmSim source repository to the ROS 2 Humble distribution index following the official ROS 2 source-indexing template.

- Repository: https://github.com/shupx/FastSwarmSim
- Source branch: `main`
- Packages in the repository: `fss_bringup`, `fss_px4_sim`, `fss_sensing`, `fss_time`, `fss_time_interfaces`
- License: BSD-3-Clause

This is intentionally a source-only entry. The `release` stanza will be submitted separately after the source repository passes review and the release repository process with `ros2-gbp` is completed, as requested in [ros2-gbp/ros2-gbp-github-org#1110](https://github.com/ros2-gbp/ros2-gbp-github-org/issues/1110).

The proposed entry follows the official template:

```yaml
  fastswarmsim:
    source:
      type: git
      url: https://github.com/shupx/FastSwarmSim.git
      version: main
    status: maintained
```

Only `humble/distribution.yaml` is changed.
