### PR TITLE
foxglove-sdk: 3.5.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2610,7 +2610,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.4.3-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.5.0-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.4.3-1`

## foxglove_bridge

```
* Add support for ROS 2 service introspection event schemas
* Fix an issue where a topic with a null schema could disrupt the discovery of subsequent topics
* Add ``video_transcode_topic_denylist`` parameter to exempt image topics (e.g. compressed depth) from video transcoding over remote access
* Add ``max_data_track_message_size`` parameter to configure the remote access gateway's lossy data-track message size limit
* Add ``video_encoder`` parameter to select the preferred video encoder backend
* Fix a crash on SIGTERM/context shutdown; the bridge now exits cleanly instead of calling ``std::terminate()``
* Update Foxglove SDK version to 0.26.0
```

## foxglove_msgs

```
* Add Event schema
```
