### PR TITLE
foxglove-sdk: 3.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3396,7 +3396,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.4.3-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.5.0-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.4.3-1`

## foxglove_bridge

```
* Transparently compress point cloud topics using draco when using remote access, with an opt-out facility
* Terminate strings for CDR serialization
* Update Foxglove SDK version to 0.27.0
```

## foxglove_msgs

```
* Version bump for foxglove_bridge 3.5.0 release
```
