### PR TITLE
mujoco_ros2_control: 0.1.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5442,7 +5442,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-controls/mujoco_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_ros2_control` to `0.1.1-1`:

- upstream repository: https://github.com/ros-controls/mujoco_ros2_control.git
- release repository: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.0-1`

## mujoco_3d_lidar

```
* Fix compilation on MuJoCo 3.12.0 (#290 <https://github.com/pal-robotics-forks/mujoco_ros2_control/issues/290>)
* Fix the generate changelog of 0.1.0 (#288 <https://github.com/pal-robotics-forks/mujoco_ros2_control/issues/288>)
* Contributors: Sai Kishor Kothakota
```

## mujoco_ros2_control

```
* Fix the generate changelog of 0.1.0 (#288 <https://github.com/pal-robotics-forks/mujoco_ros2_control/issues/288>)
* Contributors: Sai Kishor Kothakota
```

## mujoco_ros2_control_demos

```
* Fix the generate changelog of 0.1.0 (#288 <https://github.com/pal-robotics-forks/mujoco_ros2_control/issues/288>)
* Contributors: Sai Kishor Kothakota
```

## mujoco_ros2_control_msgs

- No changes

## mujoco_ros2_control_plugins

```
* Fix the generate changelog of 0.1.0 (#288 <https://github.com/pal-robotics-forks/mujoco_ros2_control/issues/288>)
* Contributors: Sai Kishor Kothakota
```
