### PR TITLE
gz_cmake_vendor: 0.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2881,7 +2881,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_cmake_vendor` to `0.5.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_cmake_vendor.git
- release repository: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.1-1`

## gz_cmake_vendor

```
* Upgrade to Rotary prerelease (#29 <https://github.com/gazebo-release/gz_cmake_vendor/issues/29>)
* Contributors: Addisu Z. Taddese
```
