### PR TITLE
gz_math_vendor: 0.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2977,7 +2977,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_math_vendor-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_math_vendor` to `0.5.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_math_vendor.git
- release repository: https://github.com/ros2-gbp/gz_math_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.1-1`

## gz_math_vendor

```
* Upgrade to Rotary prerelease (#25 <https://github.com/gazebo-release/gz_math_vendor/issues/25>)
* Contributors: Addisu Z. Taddese
```
