### PR TITLE
gz_plugin_vendor: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3041,7 +3041,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_plugin_vendor` to `0.4.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_plugin_vendor.git
- release repository: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-1`

## gz_plugin_vendor

```
* Upgrade to Rotary prerelease (#11 <https://github.com/gazebo-release/gz_plugin_vendor/issues/11>)
* Contributors: Addisu Z. Taddese
```
