### PR TITLE
Add msgpack-cxx

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8532,6 +8532,14 @@ msgpack:
   nixos: [msgpack]
   openembedded: [msgpack-c@meta-oe]
   ubuntu: [libmsgpack-dev]
+msgpack-cxx:
+  arch: [msgpack-cxx]
+  debian: [libmsgpack-cxx-dev]
+  fedora: [msgpack-devel]
+  gentoo: [dev-cpp/msgpack-cxx]
+  nixos: [msgpack-cxx]
+  openembedded: [msgpack-cxx@meta-oe]
+  ubuntu: [libmsgpack-cxx-dev]
 msr-tools:
   arch: [msr-tools]
   debian: [msr-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5137,6 +5137,16 @@ libmpich2-dev:
   gentoo: [sys-cluster/mpich2]
   nixos: [mpich]
   ubuntu: [libmpich2-dev]
+libmsgpack-cxx-dev:
+  alpine: [msgpack-cxx-dev]
+  arch: [msgpack-cxx]
+  debian: [libmsgpack-cxx-dev]
+  fedora: [msgpack-devel]
+  gentoo: [dev-cpp/msgpack-cxx]
+  nixos: [msgpack-cxx]
+  openembedded: [msgpack-cxx@meta-oe]
+  opensuse: [msgpack-cxx]
+  ubuntu: [libmsgpack-cxx-dev]
 libmsgsl-dev:
   alpine: [msgsl]
   arch: [microsoft-gsl]
@@ -8532,16 +8542,6 @@ msgpack:
   nixos: [msgpack]
   openembedded: [msgpack-c@meta-oe]
   ubuntu: [libmsgpack-dev]
-libmsgpack-cxx-dev:
-  alpine: [msgpack-cxx-dev]
-  arch: [msgpack-cxx]
-  debian: [libmsgpack-cxx-dev]
-  fedora: [msgpack-devel]
-  gentoo: [dev-cpp/msgpack-cxx]
-  nixos: [msgpack-cxx]
-  openembedded: [msgpack-cxx@meta-oe]
-  opensuse: [msgpack-cxx]
-  ubuntu: [libmsgpack-cxx-dev]
 msr-tools:
   arch: [msr-tools]
   debian: [msr-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5144,9 +5144,9 @@ libmsgpack-cxx-dev:
   fedora: [msgpack-devel]
   gentoo: [dev-cpp/msgpack-cxx]
   nixos: [msgpack-cxx]
-  openembedded: [msgpack-cxx@meta-oe]
-  opensuse: [msgpack-cxx]
-  ubuntu: [libmsgpack-cxx-dev]
+  ubuntu:
+    noble: [libmsgpack-cxx-dev]
+    resolute: [libmsgpack-cxx-dev]
 libmsgsl-dev:
   alpine: [msgsl]
   arch: [microsoft-gsl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8533,12 +8533,15 @@ msgpack:
   openembedded: [msgpack-c@meta-oe]
   ubuntu: [libmsgpack-dev]
 msgpack-cxx:
+  alpine: [msgpack-cxx-dev]
   arch: [msgpack-cxx]
   debian: [libmsgpack-cxx-dev]
   fedora: [msgpack-devel]
   gentoo: [dev-cpp/msgpack-cxx]
+  homebrew: [msgpack-cxx]
   nixos: [msgpack-cxx]
   openembedded: [msgpack-cxx@meta-oe]
+  opensuse: [msgpack-cxx]
   ubuntu: [libmsgpack-cxx-dev]
 msr-tools:
   arch: [msr-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8532,13 +8532,12 @@ msgpack:
   nixos: [msgpack]
   openembedded: [msgpack-c@meta-oe]
   ubuntu: [libmsgpack-dev]
-msgpack-cxx:
+libmsgpack-cxx-dev:
   alpine: [msgpack-cxx-dev]
   arch: [msgpack-cxx]
   debian: [libmsgpack-cxx-dev]
   fedora: [msgpack-devel]
   gentoo: [dev-cpp/msgpack-cxx]
-  homebrew: [msgpack-cxx]
   nixos: [msgpack-cxx]
   openembedded: [msgpack-cxx@meta-oe]
   opensuse: [msgpack-cxx]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`msgpack-cxx`

## Package Upstream Source:

https://github.com/msgpack/msgpack-c/tree/cpp_master

## Purpose of using this:

Currently only the C version is available. This adds the modern C++ version.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=msgpack-cxx
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/noble/msgpack-cxx
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/msgpack/msgpack-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/msgpack-cxx/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-cpp/msgpack-cxx
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=msgpack-cxx-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://mynixos.com/nixpkgs/package/msgpack-cxx
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
