### PR TITLE
lgdxrobot2_rplidar_c1: 1.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4224,6 +4224,17 @@ repositories:
       version: ros2
     status: maintained
   lgdxrobot2_rplidar_c1:
+    doc:
+      type: git
+      url: https://gitlab.com/lgdxrobotics/lgdxrobot2-rplidar-c1.git
+      version: lyrical
+    release:
+      packages:
+      - lgdx_rplidar_c1
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/lgdxrobot2_rplidar_c1-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://gitlab.com/lgdxrobotics/lgdxrobot2-rplidar-c1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgdxrobot2_rplidar_c1` to `1.0.0-1`:

- upstream repository: https://gitlab.com/lgdxrobotics/lgdxrobot2-rplidar-c1.git
- release repository: https://github.com/ros2-gbp/lgdxrobot2_rplidar_c1-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## lgdx_rplidar_c1

```
* First Release
* Contributors: Kai Tung Yu
```
