### PR TITLE
mujoco_vendor: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6770,7 +6770,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_vendor-release.git
-      version: 0.0.9-2
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/pal-robotics/mujoco_vendor.git
- release repository: https://github.com/ros2-gbp/mujoco_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.9-2`

## mujoco_vendor

```
* Remove Sergi from the maintainers
* Bump MuJoCo to 3.12.0
* Contributors: Sai Kishor Kothakota
```
