### PR TITLE
robstride_ros2: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7876,7 +7876,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robstride_ros2-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/s2015-turtle/robstride_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robstride_ros2` to `0.1.2-1`:

- upstream repository: https://github.com/s2015-turtle/robstride_ros2.git
- release repository: https://github.com/ros2-gbp/robstride_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.1-1`

## robstride_driver

```
* Apply ``gear_ratio`` when converting effort commands and feedback between
  ROS joint and motor coordinates.
* Add tests for unity and non-unity ratios with both joint directions.
* Contributors: Yamato.K
```

## robstride_examples

```
* Clarify that ``gear_ratio`` applies an ideal additional transmission to
  position, velocity, and effort.
* Contributors: Yamato.K
```

## robstride_ros2

```
* Synchronize the aggregate package version for the effort transmission
  conversion fix.
* Contributors: Yamato.K
```

## robstride_ros2_control

```
* Derive default ROS joint effort limits from motor limits through
  ``gear_ratio`` and ``direction``.
* Validate explicit joint effort limits after converting them back to motor
  clamp and CAN encoding coordinates.
* Contributors: Yamato.K
```
