### PR TITLE
gz_sensors_vendor: 0.3.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3235,7 +3235,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.3.4-1`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.3-1`

## gz_sensors_vendor

```
* Bump version to 10.1.0 (#17 <https://github.com/gazebo-release/gz_sensors_vendor/issues/17>)
* Contributors: Arjo Chakravarty
```
