### PR TITLE
rtest: 0.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9441,7 +9441,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rtest-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/Beam-and-Spyrosoft/rtest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtest` to `0.2.4-1`:

- upstream repository: https://github.com/Beam-and-Spyrosoft/rtest.git
- release repository: https://github.com/ros2-gbp/rtest-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.3-1`

## rtest

```
* Add use of NodeInterfaces for TestClock and TriggeringTestClock (#111 <https://github.com/Beam-and-Spyrosoft/rtest/issues/111>)
* fix: static analysis with clang-tidy (#124 <https://github.com/Beam-and-Spyrosoft/rtest/issues/124>)
* Contributors: Felix Blix Everberg, Sławek Cielepak
```
