### PR TITLE
Add imath rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2505,6 +2505,19 @@ imagemagick:
   nixos: [imagemagick]
   openembedded: [imagemagick@meta-oe]
   ubuntu: [imagemagick]
+imath:
+  alpine: [imath-dev]
+  arch: [imath]
+  debian: [libimath-dev]
+  fedora: [imath-devel]
+  gentoo: [dev-libs/imath]
+  nixos: [imath]
+  opensuse: [Imath-devel]
+  osx:
+    homebrew:
+      packages: [imath]
+  rhel: [imath-devel]
+  ubuntu: [libimath-dev]
 intel-gpu-tools:
   arch: [intel-gpu-tools]
   debian: [intel-gpu-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4760,12 +4760,18 @@ libimath-dev:
   fedora: [imath-devel]
   gentoo: [dev-libs/imath]
   nixos: [imath]
-  opensuse: [Imath-devel]
+  opensuse:
+    '*': [Imath-devel]
+    '15.2': null
   osx:
     homebrew:
       packages: [imath]
-  rhel: [imath-devel]
-  ubuntu: [libimath-dev]
+  rhel:
+    '*': [imath-devel]
+    '8': null
+  ubuntu:
+    '*': [libimath-dev]
+    focal: null
 libirrlicht-dev:
   arch: [irrlicht]
   debian: [libirrlicht-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2505,19 +2505,6 @@ imagemagick:
   nixos: [imagemagick]
   openembedded: [imagemagick@meta-oe]
   ubuntu: [imagemagick]
-imath:
-  alpine: [imath-dev]
-  arch: [imath]
-  debian: [libimath-dev]
-  fedora: [imath-devel]
-  gentoo: [dev-libs/imath]
-  nixos: [imath]
-  opensuse: [Imath-devel]
-  osx:
-    homebrew:
-      packages: [imath]
-  rhel: [imath-devel]
-  ubuntu: [libimath-dev]
 intel-gpu-tools:
   arch: [intel-gpu-tools]
   debian: [intel-gpu-tools]
@@ -4766,6 +4753,19 @@ libimage-exiftool-perl:
   gentoo: [media-libs/exiftool]
   nixos: [perlPackages.ImageExifTool]
   ubuntu: [libimage-exiftool-perl]
+libimath-dev:
+  alpine: [imath-dev]
+  arch: [imath]
+  debian: [libimath-dev]
+  fedora: [imath-devel]
+  gentoo: [dev-libs/imath]
+  nixos: [imath]
+  opensuse: [Imath-devel]
+  osx:
+    homebrew:
+      packages: [imath]
+  rhel: [imath-devel]
+  ubuntu: [libimath-dev]
 libirrlicht-dev:
   arch: [irrlicht]
   debian: [libirrlicht-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

imath

## Package Upstream Source:

https://github.com/AcademySoftwareFoundation/Imath

## Purpose of using this:

Imath is a required dependency of several mature graphics and simulation libraries. In our case it is required by our wave simulator, https://github.com/HonuRobotics/ehukai (a fork of the good old encinowaves).

We plan to use that wave simulator as the basis for releasing a number of maritime-related ROS packages, so an `imath` rosdep key is needed for those packages to declare the dependency in their `package.xml`.

## Links to Distribution Packages

- Debian: https://packages.debian.org/trixie/libimath-dev
- Ubuntu: https://packages.ubuntu.com/noble/libimath-dev
- Fedora: https://packages.fedoraproject.org/pkgs/imath/imath-devel/
- Arch: https://archlinux.org/packages/extra/x86_64/imath/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/imath
- macOS: https://formulae.brew.sh/formula/imath
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/imath-dev
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=25.05&show=imath&query=imath
- openSUSE: https://software.opensuse.org/package/Imath
- rhel: https://pkgs.org/download/imath-devel — note that `imath-devel` lives in
  the **CRB** repository on RHEL/CentOS Stream 9 and 10, which CONTRIBUTING.md
  allows ("Additionally, for CentOS 8+: AppStream or PowerTools").
