### PR TITLE
Add wirestead and wirestead_ros source entries (humble)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -14508,6 +14508,26 @@ repositories:
       url: https://github.com/clearpathrobotics/wireless.git
       version: foxy-devel
     status: maintained
+  wirestead:
+    doc:
+      type: git
+      url: https://github.com/wirestead/wirestead.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/wirestead/wirestead.git
+      version: main
+    status: developed
+  wirestead_ros:
+    doc:
+      type: git
+      url: https://github.com/wirestead/wirestead-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/wirestead/wirestead-ros.git
+      version: main
+    status: developed
   wrapyfi_ros2_interfaces:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -14498,20 +14498,12 @@ repositories:
       version: foxy-devel
     status: maintained
   wirestead:
-    doc:
-      type: git
-      url: https://github.com/wirestead/wirestead.git
-      version: main
     source:
       type: git
       url: https://github.com/wirestead/wirestead.git
       version: main
     status: developed
   wirestead_ros:
-    doc:
-      type: git
-      url: https://github.com/wirestead/wirestead-ros.git
-      version: main
     source:
       type: git
       url: https://github.com/wirestead/wirestead-ros.git


### PR DESCRIPTION
Adds source-only entries for `wirestead` and `wirestead_ros` to Humble.

Split out of #53281, which targeted Jazzy and Humble together. `REVIEW_GUIDELINES.md` asks that a pull request target a single rosdistro to avoid cross-coupling syncs, so #53281 now carries the Jazzy entries only and this one carries Humble.

- Source: https://github.com/wirestead/wirestead (`wirestead`), https://github.com/wirestead/wirestead-ros (`wirestead_ros`)
- Both repositories are public, carry a top-level `LICENSE`, and declare `Apache-2.0` in every `package.xml`.
- Neither is a fork of an existing ROS package.
- Source-only for now: the release repositories will be requested from `ros2-gbp` once these entries are merged, per https://github.com/ros2-gbp/ros2-gbp-github-org/blob/latest/CONTRIBUTING.md
- Humble CI (Ubuntu 22.04, Boost 1.74) is green in both repositories.
