### PR TITLE
gz_math_vendor: 0.0.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3990,7 +3990,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_math_vendor-release.git
-      version: 0.0.9-1
+      version: 0.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_math_vendor` to `0.0.10-1`:

- upstream repository: https://github.com/gazebo-release/gz_math_vendor.git
- release repository: https://github.com/ros2-gbp/gz_math_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.9-1`

## gz_math_vendor

```
* Bump version to 7.7.0 (#29 <https://github.com/gazebo-release/gz_math_vendor/issues/29>)
* Contributors: Carlos Agüero
```
