### PR TITLE
Revert "rmw_int2dds: 0.1.0-2 in 'lyrical/distribution.yaml' [bloom]"

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8074,15 +8074,6 @@ repositories:
       type: git
       url: https://github.com/IntellectusCorp/rmw_int2dds.git
       version: lyrical
-    release:
-      packages:
-      - int2dds_ffi_vendor
-      - rmw_int2dds_cpp
-      - rmw_int2dds_validation
-      tags:
-        release: release/lyrical/{package}/{version}
-      url: https://github.com/ros2-gbp/rmw_int2dds-release.git
-      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This reverts #53482.

This release has caused a circular dependency:
```
RuntimeError: Circular dependency in: ament_cmake_ros, rmw_implementation, rmw_int2dds_cpp, rmw_test_fixture_implementation
```

I haven't looked into it, but I believe that the RMW package should narrow its dependency on `ament_cmake_ros` to only `ament_cmake_ros_core`.

FYI @Intellectus-Sub