### PR TITLE
elite_cs_series_sdk: 1.5.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2802,7 +2802,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/EliteRobots/Elite_Robots_CS_SDK-release.git
-      version: 1.4.7-1
+      version: 1.5.0-2
     source:
       type: git
       url: https://github.com/EliteRobots/Elite_Robots_CS_SDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_cs_series_sdk` to `1.5.0-2`:

- upstream repository: https://github.com/EliteRobots/Elite_Robots_CS_SDK.git
- release repository: https://github.com/EliteRobots/Elite_Robots_CS_SDK-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.7-1`
