### PR TITLE
toppra: 0.6.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12672,7 +12672,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/toppra-release.git
-      version: 0.6.9-1
+      version: 0.6.10-1
     source:
       type: git
       url: https://github.com/hungpham2511/toppra.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toppra` to `0.6.10-1`:

- upstream repository: https://github.com/hungpham2511/toppra.git
- release repository: https://github.com/ros2-gbp/toppra-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.9-1`

## toppra

```
* [ros] Fix ordering of find_package for ament_cmake (#299 <https://github.com/hungpham2511/toppra/issues/299>)
* Contributors: Sebastian Castro
```
