### PR TITLE
elite_robots: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2825,7 +2825,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_robots` to `1.0.2-1`:

- upstream repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver.git
- release repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.1-1`
