### PR TITLE
Add nanobind-dev key for more operating systems

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8191,8 +8191,15 @@ nanobind-dev:
     bookworm:
       pip:
         packages: [nanobind]
+  fedora: [python3-nanobind]
   freebsd: [nanobind]
+  gentoo: [dev-python/nanobind]
   nixos: [python3Packages.nanobind]
+  openembedded: [python3-nanobind@meta-python]
+  rhel:
+    '*': [python3-nanobind]
+    '8': null
+    '9': null
   ubuntu:
     '*': [nanobind-dev]
     focal:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8185,6 +8185,7 @@ muparser:
   opensuse: [muparser-devel]
   ubuntu: [libmuparser-dev]
 nanobind-dev:
+  alpine: [py3-nanobind]
   arch: [nanobind]
   debian:
     '*': [nanobind-dev]
@@ -8196,6 +8197,12 @@ nanobind-dev:
   gentoo: [dev-python/nanobind]
   nixos: [python3Packages.nanobind]
   openembedded: [python3-nanobind@meta-python]
+  opensuse:
+    '*': [python3-nanobind-devel]
+    '15.2': null
+  osx:
+    homebrew:
+      packages: [nanobind]
   rhel:
     '*': [python3-nanobind]
     '8': null


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`nanobind-dev`

## Package Upstream Source:

https://github.com/wjakob/nanobind

## Purpose of using this:

It's the successor to `pybind11-dev`, which is used by several libraries. This PR is sparked by https://github.com/ros2/rclpy/pull/1707#issuecomment-5208250411

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - already available
- Ubuntu: https://packages.ubuntu.com/
  - already evailable
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-nanobind/python3-nanobind/
- Arch: https://www.archlinux.org/packages/
  - already available
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/nanobind
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/nanobind
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86/py3-nanobind
- NixOS/nixpkgs: https://search.nixos.org/packages
  - already available
- OpenEmbedded:
  - https://layers.openembedded.org/layerindex/recipe/440776/
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python-nanobind
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/raven-x86_64/python3-nanobind-2.9.0-1.el9.noarch.rpm.html