### PR TITLE
moveit: 2.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4840,7 +4840,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.15.0-1
+      version: 2.15.1-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.15.1-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.0-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_hybrid_planning

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_kinematics

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Fix IKFast plugin compilation
  The generated solver is no longer included inside the plugin namespace's
  transitive include set: required standard headers are now included at global
  scope. Fixes the build on Rolling, where rclcpp no longer provides <list>.
* Guard clang-specific pragma
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_planners_stomp

- No changes

## moveit_plugins

- No changes

## moveit_py

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Fix IKFast plugin compilation
  The generated solver is no longer included inside the plugin namespace's
  transitive include set: required standard headers are now included at global
  scope. Fixes the build on Rolling, where rclcpp no longer provides <list>.
* Contributors: Robert Haschke
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_ros_control_interface

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Address review comments
* add missing header for unordered_set
* remove unused queue header
* Avoid using deprecated FindBoost.cmake module
* Contributors: Christian Rauch, Robert Haschke
```

## moveit_ros_move_group

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_ros_occupancy_map_monitor

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_ros_perception

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Address review comments
* Update 'CreateTimerROS' constructor API
  tf2_ros removed the two-interface constructor. Guarded so one branch builds
  on every supported distro.
* Avoid using deprecated FindBoost.cmake module
* Contributors: Christian Rauch, Robert Haschke
```

## moveit_ros_planning

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_ros_planning_interface

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

- No changes

## moveit_ros_visualization

```
* Modernize Qt signal-slot connections to use function pointers (#3823 <https://github.com/moveit/moveit2/issues/3823>)
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Address review comments
* Avoid using deprecated FindBoost.cmake module
* Contributors: Christian Rauch, Robert Haschke
```

## moveit_ros_warehouse

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Fix Qt deprecations
* Contributors: Robert Haschke
```

## moveit_setup_srdf_plugins

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Fix Qt deprecations
* Contributors: Robert Haschke
```

## moveit_simple_controller_manager

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## pilz_industrial_motion_planner

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```

## pilz_industrial_motion_planner_testutils

```
* Fix CI on Ubuntu 26.04 (#3818 <https://github.com/moveit/moveit2/issues/3818>)
* Avoid using deprecated FindBoost.cmake module
* Contributors: Robert Haschke
```
