### PR TITLE
[openembedded] python3-black: move from meta-ros to meta-python

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -119,7 +119,7 @@ black:
   fedora: [black]
   gentoo: [dev-python/black]
   nixos: [python3Packages.black]
-  openembedded: [python3-black@meta-ros]
+  openembedded: [python3-black@meta-python]
   ubuntu:
     '*': [black]
     bionic: null


### PR DESCRIPTION
The recipe in meta-python of meta-openembedded is more recent.

@robwoolley I can remove the recipe from meta-ros2, if you agree and once merged into rosdistro and released on Rolling.