### PR TITLE
rbq_ros2: 1.20.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9179,6 +9179,13 @@ repositories:
       version: humble-devel
     status: maintained
   rbq_ros2:
+    release:
+      packages:
+      - rbq_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rbq_ros2-release.git
+      version: 1.20.0-1
     source:
       type: git
       url: https://github.com/RainbowRobotics/rbq_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rbq_ros2` to `1.20.0-1`:

- upstream repository: https://github.com/RainbowRobotics/rbq_ros2.git
- release repository: https://github.com/ros2-gbp/rbq_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
