### PR TITLE
ehukai: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1923,6 +1923,23 @@ repositories:
       url: https://github.com/stonier/ecl_tools.git
       version: devel
     status: maintained
+  ehukai:
+    doc:
+      type: git
+      url: https://github.com/HonuRobotics/ehukai.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/HonuRobotics/ehukai-release.git
+      version: 0.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/HonuRobotics/ehukai.git
+      version: main
+    status: developed
+    status_description: Active development
   eigen3_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ehukai` to `0.0.3-1`:

- upstream repository: https://github.com/HonuRobotics/ehukai
- release repository: https://github.com/HonuRobotics/ehukai-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## ehukai

```
* Declare the Imath dependency as the ``libimath-dev`` rosdep key.
* Make the Debian packaging opt-in via ``EHUKAI_ENABLE_DEB_PACKAGING`` so its
  copyright, changelog and lintian overrides stop appearing in every install.
* Install ``package.xml`` to ``share/ehukai``.
* Give the manifest an author, a license file and a bugtracker URL.
* Add a dependabot configuration for automated dependency updates.
```
