### PR TITLE
rcutils: 7.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7077,7 +7077,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.2.1-1
+      version: 7.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.2.2-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.2.1-1`

## rcutils

```
* Remove the bundled gcc stdatomic compatibility header (#589 <https://github.com/ros2/rcutils/issues/589>)
* an explicit platform split matching the helper header's own condition. (#587 <https://github.com/ros2/rcutils/issues/587>)
* Normalize extern "C" guards to #ifdef __cplusplus (#585 <https://github.com/ros2/rcutils/issues/585>)
* Fix date_time_with_ms millisecond formatting (#570 <https://github.com/ros2/rcutils/issues/570>)
* Added missing headers (#580 <https://github.com/ros2/rcutils/issues/580>)
* Link rcutils against Threads (#579 <https://github.com/ros2/rcutils/issues/579>)
* Contributors: Alejandro Hernández Cordero, Mark Jin, Michael Carroll, Tobias Fischer, Tomoya Fujita, zacheryasc
```
