### PR TITLE
rcutils: 7.1.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7461,7 +7461,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.1.2-1
+      version: 7.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.1.3-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.1.2-1`

## rcutils

```
* an explicit platform split matching the helper header's own condition. (#587 <https://github.com/ros2/rcutils/issues/587>) (#590 <https://github.com/ros2/rcutils/issues/590>)
* Added missing headers (#580 <https://github.com/ros2/rcutils/issues/580>) (#581 <https://github.com/ros2/rcutils/issues/581>)
* Contributors: mergify[bot]
```
