### PR TITLE
ros_gz: 4.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8312,7 +8312,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `4.0.1-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.0-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Break the parameter bridge handle ownership cycle (#952 <https://github.com/gazebosim/ros_gz/issues/952>)
* Document supported service bridge types (#928 <https://github.com/gazebosim/ros_gz/issues/928>)
* ros_gz_bridge: Explicitly handle visibility of exported symbols (#930 <https://github.com/gazebosim/ros_gz/issues/930>)
* Correctly initialize std::atomic_flag with ATOMIC_FLAG_INIT (#929 <https://github.com/gazebosim/ros_gz/issues/929>)
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>)
* Contributors: Jiayi Cai, Sammy Dabbas, Silvio Traversaro, yeseorizi
```

## ros_gz_image

- No changes

## ros_gz_interfaces

```
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>)
* Contributors: Sammy Dabbas
```

## ros_gz_sim

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>)
* Set default spawn pose arguments to 0.0 (#926 <https://github.com/gazebosim/ros_gz/issues/926>)
* Fix GzSpawnModel defaults for omitted arguments (#909 <https://github.com/gazebosim/ros_gz/issues/909>)
* Contributors: Jiayi Cai
```

## ros_gz_sim_demos

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>)
* update vehicle model to spawn above ground (#921 <https://github.com/gazebosim/ros_gz/issues/921>)
* Contributors: Jiayi Cai, Kimberly McGuire
```
