### PR TITLE
ros_gz: 3.0.10-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8721,7 +8721,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.9-1
+      version: 3.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.10-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.9-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Document supported service bridge types (#928 <https://github.com/gazebosim/ros_gz/issues/928>) (#942 <https://github.com/gazebosim/ros_gz/issues/942>)
* Correctly initialize std::atomic_flag with ATOMIC_FLAG_INIT (#929 <https://github.com/gazebosim/ros_gz/issues/929>) (#934 <https://github.com/gazebosim/ros_gz/issues/934>)
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>) (#915 <https://github.com/gazebosim/ros_gz/issues/915>)
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

```
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>) (#915 <https://github.com/gazebosim/ros_gz/issues/915>)
* Contributors: mergify[bot]
```

## ros_gz_sim

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>) (#946 <https://github.com/gazebosim/ros_gz/issues/946>)
* Set default spawn pose arguments to 0.0 (#926 <https://github.com/gazebosim/ros_gz/issues/926>) (#939 <https://github.com/gazebosim/ros_gz/issues/939>)
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>) (#946 <https://github.com/gazebosim/ros_gz/issues/946>)
* update vehicle model to spawn above ground (#921 <https://github.com/gazebosim/ros_gz/issues/921>)
* Contributors: Kimberly McGuire, mergify[bot]
```
