### PR TITLE
gz_ros2_control: 3.0.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3222,7 +3222,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 3.0.8-1
+      version: 3.0.9-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `3.0.9-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.8-1`

## gz_ros2_control

```
* Apply the mimic joint offset in GazeboSimSystem::write (#953 <https://github.com/ros-controls/gz_ros2_control/issues/953>) (#956 <https://github.com/ros-controls/gz_ros2_control/issues/956>)
* Fix command mode stop masks (#899 <https://github.com/ros-controls/gz_ros2_control/issues/899>) (#919 <https://github.com/ros-controls/gz_ros2_control/issues/919>)
* Fix portable entity ID logging (#900 <https://github.com/ros-controls/gz_ros2_control/issues/900>) (#915 <https://github.com/ros-controls/gz_ros2_control/issues/915>)
* Use portable Gazebo entity ID formatting (#882 <https://github.com/ros-controls/gz_ros2_control/issues/882>) (#905 <https://github.com/ros-controls/gz_ros2_control/issues/905>)
* Avoid Windows ERROR macro conflict in gz_system (#883 <https://github.com/ros-controls/gz_ros2_control/issues/883>) (#895 <https://github.com/ros-controls/gz_ros2_control/issues/895>)
* Fix plugin loading in gazebo (#876 <https://github.com/ros-controls/gz_ros2_control/issues/876>) (#878 <https://github.com/ros-controls/gz_ros2_control/issues/878>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Apply the mimic joint offset in GazeboSimSystem::write (#953 <https://github.com/ros-controls/gz_ros2_control/issues/953>) (#956 <https://github.com/ros-controls/gz_ros2_control/issues/956>)
* Update mininum CMakeLists.txt version (#870 <https://github.com/ros-controls/gz_ros2_control/issues/870>) (#942 <https://github.com/ros-controls/gz_ros2_control/issues/942>)
* Enable MSVC math constants for custom demo plugin (#884 <https://github.com/ros-controls/gz_ros2_control/issues/884>) (#901 <https://github.com/ros-controls/gz_ros2_control/issues/901>)
* Use correct tricycle_controller as dependency (#861 <https://github.com/ros-controls/gz_ros2_control/issues/861>) (#862 <https://github.com/ros-controls/gz_ros2_control/issues/862>)
* Contributors: mergify[bot]
```
