### PR TITLE
ros_gz: 2.1.18-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8405,7 +8405,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.17-1
+      version: 2.1.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.18-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.17-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Document supported service bridge types (#928 <https://github.com/gazebosim/ros_gz/issues/928>) (#943 <https://github.com/gazebosim/ros_gz/issues/943>)
* Correctly initialize std::atomic_flag with ATOMIC_FLAG_INIT (#929 <https://github.com/gazebosim/ros_gz/issues/929>) (#935 <https://github.com/gazebosim/ros_gz/issues/935>)
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>) (#916 <https://github.com/gazebosim/ros_gz/issues/916>)
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

```
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>) (#916 <https://github.com/gazebosim/ros_gz/issues/916>)
* Contributors: mergify[bot]
```

## ros_gz_sim

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>) (#947 <https://github.com/gazebosim/ros_gz/issues/947>)
* Set default spawn pose arguments to 0.0 (#926 <https://github.com/gazebosim/ros_gz/issues/926>) (#940 <https://github.com/gazebosim/ros_gz/issues/940>)
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>) (#947 <https://github.com/gazebosim/ros_gz/issues/947>)
* update vehicle model to spawn above ground (#921 <https://github.com/gazebosim/ros_gz/issues/921>)
* Contributors: Kimberly McGuire, mergify[bot]
```
