### PR TITLE
ros_gz: 1.0.24-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10367,7 +10367,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.23-1
+      version: 1.0.24-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.24-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.23-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Document supported service bridge types (#928 <https://github.com/gazebosim/ros_gz/issues/928>) (#944 <https://github.com/gazebosim/ros_gz/issues/944>)
* Correctly initialize std::atomic_flag with ATOMIC_FLAG_INIT (#929 <https://github.com/gazebosim/ros_gz/issues/929>) (#936 <https://github.com/gazebosim/ros_gz/issues/936>)
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>) (#917 <https://github.com/gazebosim/ros_gz/issues/917>)
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

```
* Add AirSpeed message and bridge mapping (#914 <https://github.com/gazebosim/ros_gz/issues/914>) (#917 <https://github.com/gazebosim/ros_gz/issues/917>)
* Contributors: mergify[bot]
```

## ros_gz_sim

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>) (#948 <https://github.com/gazebosim/ros_gz/issues/948>)
* Set default spawn pose arguments to 0.0 (#926 <https://github.com/gazebosim/ros_gz/issues/926>) (#941 <https://github.com/gazebosim/ros_gz/issues/941>)
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

```
* Fix entity type values in sim tools and docs (#927 <https://github.com/gazebosim/ros_gz/issues/927>) (#948 <https://github.com/gazebosim/ros_gz/issues/948>)
* update vehicle model to spawn above ground (#921 <https://github.com/gazebosim/ros_gz/issues/921>)
* Contributors: Kimberly McGuire, mergify[bot]
```
