### PR TITLE
gz_ros2_control: 1.2.20-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4078,7 +4078,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.19-1
+      version: 1.2.20-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.20-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.19-1`

## gz_ros2_control

```
* Apply the mimic joint offset in GazeboSimSystem::write (#953 <https://github.com/ros-controls/gz_ros2_control/issues/953>) (#954 <https://github.com/ros-controls/gz_ros2_control/issues/954>)
* Remove linters from test stage (backport #668 <https://github.com/ros-controls/gz_ros2_control/issues/668>) (#940 <https://github.com/ros-controls/gz_ros2_control/issues/940>)
* Fix command mode stop masks (#899 <https://github.com/ros-controls/gz_ros2_control/issues/899>) (#921 <https://github.com/ros-controls/gz_ros2_control/issues/921>)
* Fix portable entity ID logging (#900 <https://github.com/ros-controls/gz_ros2_control/issues/900>) (#917 <https://github.com/ros-controls/gz_ros2_control/issues/917>)
* Use portable Gazebo entity ID formatting (backport #882 <https://github.com/ros-controls/gz_ros2_control/issues/882>) (#907 <https://github.com/ros-controls/gz_ros2_control/issues/907>)
* Avoid Windows ERROR macro conflict in gz_system (backport #883 <https://github.com/ros-controls/gz_ros2_control/issues/883>) (#897 <https://github.com/ros-controls/gz_ros2_control/issues/897>)
* Fix plugin loading in gazebo (#876 <https://github.com/ros-controls/gz_ros2_control/issues/876>) (#880 <https://github.com/ros-controls/gz_ros2_control/issues/880>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Apply the mimic joint offset in GazeboSimSystem::write (#953 <https://github.com/ros-controls/gz_ros2_control/issues/953>) (#954 <https://github.com/ros-controls/gz_ros2_control/issues/954>)
* Remove linters from test stage (backport #668 <https://github.com/ros-controls/gz_ros2_control/issues/668>) (#940 <https://github.com/ros-controls/gz_ros2_control/issues/940>)
* Enable MSVC math constants for custom demo plugin (#884 <https://github.com/ros-controls/gz_ros2_control/issues/884>) (#903 <https://github.com/ros-controls/gz_ros2_control/issues/903>)
* Use correct tricycle_controller as dependency (#861 <https://github.com/ros-controls/gz_ros2_control/issues/861>) (#864 <https://github.com/ros-controls/gz_ros2_control/issues/864>)
* Remove deprecated has_*_limits parameters from diff_drive_controller config (#845 <https://github.com/ros-controls/gz_ros2_control/issues/845>) (#859 <https://github.com/ros-controls/gz_ros2_control/issues/859>)
* Contributors: mergify[bot]
```
