### PR TITLE
rcl: 10.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6878,7 +6878,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.5.1-1
+      version: 10.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.5.2-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `10.5.1-1`

## rcl

```
* Fix deprecated atomic initialization (#1332 <https://github.com/ros2/rcl/issues/1332>)
* use C++ 20 in default. (#1322 <https://github.com/ros2/rcl/issues/1322>)
* Contributors: Maurice Alexander Purnawan, Tomoya Fujita
```

## rcl_action

```
* introduce rcl_action_endpoint_info_array_t. (#1326 <https://github.com/ros2/rcl/issues/1326>)
* use C++ 20 in default. (#1322 <https://github.com/ros2/rcl/issues/1322>)
* Contributors: Tomoya Fujita
```

## rcl_lifecycle

```
* use C++ 20 in default. (#1322 <https://github.com/ros2/rcl/issues/1322>)
* Contributors: Tomoya Fujita
```

## rcl_yaml_param_parser

```
* rcl_yaml_param_parser: Fix build on MacOS (#1327 <https://github.com/ros2/rcl/issues/1327>)
* Use pthread_once in rcl_yaml_param_parser on Apple (#1325 <https://github.com/ros2/rcl/issues/1325>)
* use C++ 20 in default. (#1322 <https://github.com/ros2/rcl/issues/1322>)
* Contributors: Michal Sojka, Tobias Fischer, Tomoya Fujita
```
