### PR TITLE
rclcpp: 33.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6994,7 +6994,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 33.0.4-1
+      version: 33.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `33.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `33.0.4-1`

## rclcpp

```
* Reject incompatible parameter range constraints (#3243 <https://github.com/ros2/rclcpp/issues/3243>)
* cleanup headers (#3238 <https://github.com/ros2/rclcpp/issues/3238>)
* Fix possible race condition with reentrant callback groups in EventsCBGExecutor scheduler (#3234 <https://github.com/ros2/rclcpp/issues/3234>)
* Add wait_for_message API that relies on node interfaces (#3230 <https://github.com/ros2/rclcpp/issues/3230>)
* Add test for infinite value in float range bound (#3218 <https://github.com/ros2/rclcpp/issues/3218>)
* Add RCLCPP_*_FORMAT logging macros  (#2263 <https://github.com/ros2/rclcpp/issues/2263>)
* fix: prevent double-shutdown in rclcpp::Context (#3220 <https://github.com/ros2/rclcpp/issues/3220>)
* Move get_log_directory to improve compilation time (#3214 <https://github.com/ros2/rclcpp/issues/3214>)
* honor cancel() issued before spin_until_future_complete(). (#3174 <https://github.com/ros2/rclcpp/issues/3174>)
* Contributors: Alejandro Hernández Cordero, Nathan Wiebe Neufeldt, Skyler Medeiros, Tomoya Fujita, aiqubits, pum1k, yadunund
```

## rclcpp_action

```
* cleanup headers (#3238 <https://github.com/ros2/rclcpp/issues/3238>)
* introduce ActionEndpointInfo from action graph. (#3209 <https://github.com/ros2/rclcpp/issues/3209>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita
```

## rclcpp_components

```
* cleanup headers (#3238 <https://github.com/ros2/rclcpp/issues/3238>)
* rclcpp_components: Fix compilation with clang (#3229 <https://github.com/ros2/rclcpp/issues/3229>)
* Fix race condition when creating isolated component container (#3223 <https://github.com/ros2/rclcpp/issues/3223>)
* Contributors: Alejandro Hernández Cordero, Michal Sojka, Tony Najjar
```

## rclcpp_lifecycle

```
* cleanup headers (#3238 <https://github.com/ros2/rclcpp/issues/3238>)
* Add wait_for_message API that relies on node interfaces (#3230 <https://github.com/ros2/rclcpp/issues/3230>)
* Support generic subscription callbacks in LifecycleNode (#3227 <https://github.com/ros2/rclcpp/issues/3227>)
* clarify difference between faliure and error : issue-3086 (#3215 <https://github.com/ros2/rclcpp/issues/3215>)
* Contributors: Aditya Jindal, Alejandro Hernández Cordero, Maurice Alexander Purnawan, yadunund
```
