### PR TITLE
rcl: 10.4.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7262,7 +7262,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.4.4-1
+      version: 10.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.4.5-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `10.4.4-1`

## rcl

```
* Fix deprecated atomic initialization (#1332 <https://github.com/ros2/rcl/issues/1332>) (#1333 <https://github.com/ros2/rcl/issues/1333>)
* Contributors: mergify[bot]
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* rcl_yaml_param_parser: Fix build on MacOS (#1327 <https://github.com/ros2/rcl/issues/1327>) (#1329 <https://github.com/ros2/rcl/issues/1329>)
* Use pthread_once in rcl_yaml_param_parser on Apple (#1325 <https://github.com/ros2/rcl/issues/1325>) (#1328 <https://github.com/ros2/rcl/issues/1328>)
* Contributors: mergify[bot]
```
