### PR TITLE
rclcpp: 28.1.22-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8939,7 +8939,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.21-1
+      version: 28.1.22-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.22-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `28.1.21-1`

## rclcpp

```
* register shutdown callback without shutdown mutex (#3239 <https://github.com/ros2/rclcpp/issues/3239>)
* Fix possible race condition with reentrant callback groups in EventsCBGExecutor scheduler (#3234 <https://github.com/ros2/rclcpp/issues/3234>) (#3236 <https://github.com/ros2/rclcpp/issues/3236>)
* address context shutdown racy condition. (#3219 <https://github.com/ros2/rclcpp/issues/3219>) (#3225 <https://github.com/ros2/rclcpp/issues/3225>)
* add support for reentrant callback groups (#3205 <https://github.com/ros2/rclcpp/issues/3205>)
* Contributors: Skyler Medeiros, mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Check for association with an executor before removing nodes in ComponentManager (#3190 <https://github.com/ros2/rclcpp/issues/3190>) (#3197 <https://github.com/ros2/rclcpp/issues/3197>)
* Contributors: mergify[bot]
```

## rclcpp_lifecycle

- No changes
