### PR TITLE
Remove gz_launch_vendor from Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2941,22 +2941,6 @@ repositories:
       url: https://github.com/gazebo-release/gz_gui_vendor.git
       version: rolling
     status: maintained
-  gz_launch_vendor:
-    doc:
-      type: git
-      url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/gz_launch_vendor-release.git
-      version: 0.4.1-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: rolling
-    status: maintained
   gz_math_vendor:
     doc:
       type: git


### PR DESCRIPTION
gz-launch was deprecated in Gazebo Jetty and has been removed from Rotary, which is now paired with Rolling. 

I'm hoping this will stop the Rbin builds (e.g. https://build.ros2.org/job/Rbin_uR64__gz_launch_vendor__ubuntu_resolute_amd64__binary/) for gz_launch_vendor, but I'm not sure.
