### PR TITLE
rclcpp: 16.0.20-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9397,7 +9397,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.19-1
+      version: 16.0.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.20-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `16.0.19-1`

## rclcpp

```
* address context shutdown racy condition. (#3219 <https://github.com/ros2/rclcpp/issues/3219>) (#3224 <https://github.com/ros2/rclcpp/issues/3224>)
* add missing header for std::function (#3211 <https://github.com/ros2/rclcpp/issues/3211>)
* node_interfaces.hpp: add missing include of stdexcept (#3210 <https://github.com/ros2/rclcpp/issues/3210>)
* chore: fix typo in test_time_source.cpp (#3145 <https://github.com/ros2/rclcpp/issues/3145>) (#3150 <https://github.com/ros2/rclcpp/issues/3150>)
* Contributors: Fabian Hirmann, Guilhem Saurel, mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
