### PR TITLE
pluginlib: 6.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6253,7 +6253,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 6.0.1-1
+      version: 6.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `6.0.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.1-1`

## pluginlib

```
* Fix pluginlib_enable_plugin_testing() docstring pitfalls. (#305 <https://github.com/ros/pluginlib/issues/305>)
* Contributors: Chris Lalancette
```

## ros2plugin

- No changes
