### PR TITLE
pluginlib: 5.8.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6602,7 +6602,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.8.4-3
+      version: 5.8.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.8.5-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.8.4-3`

## pluginlib

```
* Fix pluginlib_enable_plugin_testing() docstring pitfalls. (#305 <https://github.com/ros/pluginlib/issues/305>) (#306 <https://github.com/ros/pluginlib/issues/306>)
* Removed dead code (#299 <https://github.com/ros/pluginlib/issues/299>) (#301 <https://github.com/ros/pluginlib/issues/301>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```

## ros2plugin

- No changes
