### PR TITLE
pluginlib: 5.6.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6414,7 +6414,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.6.3-1
+      version: 5.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.6.4-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.6.3-1`

## pluginlib

```
* Fix pluginlib_enable_plugin_testing() docstring pitfalls. (#305 <https://github.com/ros/pluginlib/issues/305>) (#307 <https://github.com/ros/pluginlib/issues/307>)
* Removed dead code (#299 <https://github.com/ros/pluginlib/issues/299>) (#302 <https://github.com/ros/pluginlib/issues/302>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```

## ros2plugin

- No changes
