### PR TITLE
pluginlib: 5.4.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7960,7 +7960,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.4.5-1
+      version: 5.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.4.6-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.4.5-1`

## pluginlib

```
* Fix pluginlib_enable_plugin_testing() docstring pitfalls. (#305 <https://github.com/ros/pluginlib/issues/305>) (#308 <https://github.com/ros/pluginlib/issues/308>)
* Removed dead code (backport #299 <https://github.com/ros/pluginlib/issues/299>) (#303 <https://github.com/ros/pluginlib/issues/303>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```

## ros2plugin

- No changes
