### PR TITLE
pluginlib: 5.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8391,7 +8391,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.1.4-1
+      version: 5.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.1.5-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.1.4-1`

## pluginlib

```
* Fix pluginlib_enable_plugin_testing() docstring pitfalls. (#305 <https://github.com/ros/pluginlib/issues/305>) (#309 <https://github.com/ros/pluginlib/issues/309>)
* Removed dead code (backport #299 <https://github.com/ros/pluginlib/issues/299>) (#304 <https://github.com/ros/pluginlib/issues/304>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```

## ros2plugin

- No changes
