### PR TITLE
jig: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4682,6 +4682,19 @@ repositories:
       version: main
     status: maintained
   jig:
+    doc:
+      type: git
+      url: https://github.com/nineyards-robotics/jig.git
+      version: main
+    release:
+      packages:
+      - jig
+      - jig_cli
+      - jig_example
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/jig-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/nineyards-robotics/jig.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jig` to `0.0.2-1`:

- upstream repository: https://github.com/nineyards-robotics/jig.git
- release repository: https://github.com/ros2-gbp/jig-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## jig

- No changes

## jig_cli

- No changes

## jig_example

- No changes
