### PR TITLE
gz_utils_vendor: 0.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3251,7 +3251,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
-      version: 0.2.2-2
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_utils_vendor` to `0.3.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_utils_vendor.git
- release repository: https://github.com/ros2-gbp/gz_utils_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.2-2`

## gz_utils_vendor

```
* Enable Python bindings (#15 <https://github.com/gazebo-release/gz_utils_vendor/issues/15>)
* Contributors: Addisu Z. Taddese
```
