### PR TITLE
py_binding_tools: 2.1.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8260,11 +8260,15 @@ repositories:
       version: main
     status: maintained
   py_binding_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/py_binding_tools.git
+      version: ros2
     release:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros-gbp/py_binding_tools-release.git
-      version: 2.0.1-1
+      version: 2.1.4-1
     source:
       type: git
       url: https://github.com/ros-planning/py_binding_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `2.1.4-1`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros-gbp/py_binding_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-1`

## py_binding_tools

```
* Fix dependency on pybind11
* Contributors: Robert Haschke
```
