### PR TITLE
py_binding_tools: 2.1.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6425,7 +6425,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_binding_tools-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       type: git
       url: https://github.com/ros-planning/py_binding_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `2.1.4-1`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros2-gbp/py_binding_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.3-1`

## py_binding_tools

```
* Fix dependency on pybind11
* Contributors: Robert Haschke
```
