### PR TITLE
moveit_task_constructor: 0.1.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5174,7 +5174,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_task_constructor-release.git
-      version: 0.1.6-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/moveit/moveit_task_constructor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_task_constructor` to `0.1.7-1`:

- upstream repository: https://github.com/moveit/moveit_task_constructor.git
- release repository: https://github.com/ros2-gbp/moveit_task_constructor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.6-1`

## moveit_task_constructor_capabilities

```
* Fix integration test (#760 <https://github.com/moveit/moveit_task_constructor/issues/760>)
* Contributors: ktyang512
```

## moveit_task_constructor_core

```
* Switch to standard pybind11 v3 / Remove submodule
* Fix integration test (#760 <https://github.com/moveit/moveit_task_constructor/issues/760>)
* Contributors: Robert Haschke, ktyang512
```

## moveit_task_constructor_demo

- No changes

## moveit_task_constructor_msgs

- No changes

## moveit_task_constructor_visualization

- No changes

## rviz_marker_tools

- No changes
