### PR TITLE
rmw_int2dds: 0.1.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10042,11 +10042,10 @@ repositories:
       packages:
       - int2dds_ffi_vendor
       - rmw_int2dds_cpp
-      - rmw_int2dds_validation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_int2dds-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/IntellectusCorp/rmw_int2dds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_int2dds` to `0.1.1-2`:

- upstream repository: https://github.com/IntellectusCorp/rmw_int2dds.git
- release repository: https://github.com/ros2-gbp/rmw_int2dds-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.1-1`

## int2dds_ffi_vendor

```
* No source changes; released in lockstep with ``rmw_int2dds_cpp``.
* Contributors: Intellectus Corp.
```

## rmw_int2dds_cpp

```
* Shrink the initial subscription receive buffer to 64 KiB. It is held per
  subscription and zeroed by ``resize()``, so 2 MiB went resident on every first
  take; larger payloads still work through the existing grow-on-demand path.
* Defer guard condition destruction until no wait set can reach it.
* Include ``<utility>`` for ``std::move`` in the wait set registry.
* Free the sample sequence when a take returns no data.
* Poll for NOT_ALIVE endpoints instead of waiting for them.
* Load the ``ament_cmake_ros`` buildtool dependency the package already declared.
  Declaring without loading it set neither ``BUILD_SHARED_LIBS`` nor
  ``ROS_PACKAGE_NAME``.
* Add ``testing/check-dependency-cycle.py``, which replays the build farm's
  release job sort over this checkout, next to the container test harness.
* Run that check in CI on every push and pull request to this branch.
* Contributors: Intellectus Corp.
```
