### PR TITLE
Add rqt_lifecycle_manager to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9082,6 +9082,16 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: rolling-devel
     status: maintained
+  rqt_lifecycle_manager:
+    doc:
+      type: git
+      url: https://github.com/ajtudela/rqt_lifecycle_manager.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ajtudela/rqt_lifecycle_manager.git
+      version: rolling
+    status: maintained
   rqt_moveit:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/ajtudela/rqt_lifecycle_manager.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
