### PR TITLE
rclpy: 10.0.11-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7394,7 +7394,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.10-1
+      version: 10.0.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `10.0.11-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `10.0.10-1`

## rclpy

```
* Fix future-wait callback accumulation on every spin path (#1702 <https://github.com/ros2/rclpy/issues/1702>) (#1716 <https://github.com/ros2/rclpy/issues/1716>)
* fix: node lingering after destroy (backport lyrical #1711 <https://github.com/ros2/rclpy/issues/1711>) (#1714 <https://github.com/ros2/rclpy/issues/1714>)
* Use perf_counter() rather than monotonic() for consistency. (#1712 <https://github.com/ros2/rclpy/issues/1712>) (#1715 <https://github.com/ros2/rclpy/issues/1715>)
* Fix rclpy async executor sleep. (#1661 <https://github.com/ros2/rclpy/issues/1661>) (#1676 <https://github.com/ros2/rclpy/issues/1676>)
* Handle exceptions in lifecycle transition callbacks (#1696 <https://github.com/ros2/rclpy/issues/1696>) (#1698 <https://github.com/ros2/rclpy/issues/1698>)
* Fix incorrect parameter names in docstrings (#1685 <https://github.com/ros2/rclpy/issues/1685>) (#1691 <https://github.com/ros2/rclpy/issues/1691>)
* Fix incorrect parameter names in docstrings (#1683 <https://github.com/ros2/rclpy/issues/1683>) (#1686 <https://github.com/ros2/rclpy/issues/1686>)
* Contributors: mergify[bot]
```
