### PR TITLE
ros2cli: 0.42.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8169,6 +8169,7 @@ repositories:
       - ros2interface
       - ros2lifecycle
       - ros2lifecycle_test_fixtures
+      - ros2log
       - ros2multicast
       - ros2node
       - ros2param
@@ -8179,7 +8180,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.41.1-1
+      version: 0.42.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.42.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.41.1-1`

## ros2action

```
* support ""ros2 action info (-v)" with ActionEndpointInfo. (#1262 <https://github.com/ros2/ros2cli/issues/1262>)
* Contributors: Tomoya Fujita
```

## ros2cli

```
* Keep leading '~' unquoted in zsh completion. (#1279 <https://github.com/ros2/ros2cli/issues/1279>) (#1281 <https://github.com/ros2/ros2cli/issues/1281>)
* support ""ros2 action info (-v)" with ActionEndpointInfo. (#1262 <https://github.com/ros2/ros2cli/issues/1262>)
* Contributors: Tomoya Fujita
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Add multicast options to ros2 doctor hello (#1267 <https://github.com/ros2/ros2cli/issues/1267>)
* Contributors: Miko Parkkinen
```

## ros2interface

```
* fix non standard interface locations. (#1186 <https://github.com/ros2/ros2cli/issues/1186>) (#1283 <https://github.com/ros2/ros2cli/issues/1283>)
* Contributors: Alejandro Hernández Cordero
```

## ros2lifecycle

```
* Test ros2 lifecycle output streams (#1266 <https://github.com/ros2/ros2cli/issues/1266>)
* Contributors: Miko Parkkinen
```

## ros2lifecycle_test_fixtures

- No changes

## ros2log

```
* ros2log new package introduction (#1217 <https://github.com/ros2/ros2cli/issues/1217>)
  * 1st draft bring up for "ros2 log watch" sub-command.
  clean up the package and implementation.
  fix ros2log test_watch.py.
  support QoS configuration argument for ros2 log watch.
  Call content filtering API for logger name and level if available.
  add test_cli.py to test "ros2 log watch".
  remove ros2log/README.md.
  :construction: add list subcommand
  bug: fix test
  :recycle: delete non-necessary fixture node for test
  :bug: fix to print one by one
  support "ros2 log levels".
  :zap: add get and set subcommand
  :bug: align logger's initial state during test
  FIX: add sleep to reduce cpu consumption
  FIX: rewrite waiting acync process
  :FIX: delete --include-hidden-nodes option
  FIX: import from api
  FIX: add ValueError when empty string is inputted in get_absolute_node_name
  * fix copyright year
  * fix to destroy clients
  * fix to remove dependencies
  * add missing dependencies
  * fix type annotation
  * add type hints to node
  * Update ros2log/ros2log/verb/watch.py
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  * Update ros2log/ros2log/verb/watch.py
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  * Update ros2log/ros2log/verb/watch.py
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  * Update ros2log/ros2log/api/__init__.py
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  * add checking negative timeout_sec
  * LogWatcher constructor should raise the exception instead of sys.exit().
  * address copilot review comments.
  * address review comments.
  ---------
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: Decwest <mailto:fumiyaonishi1016@gmail.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Tomoya Fujita
```

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

```
* feat(ros2pkg): Install headers into subdirectory (#1280 <https://github.com/ros2/ros2cli/issues/1280>)
* Contributors: Martin Pecka
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
