### PR TITLE
rclpy: 9.1.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7180,7 +7180,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 9.1.6-1
+      version: 9.1.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `9.1.7-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.1.6-1`

## rclpy

```
* Handle exceptions in lifecycle transition callbacks (#1696 <https://github.com/ros2/rclpy/issues/1696>) (#1699 <https://github.com/ros2/rclpy/issues/1699>)
* Bugfix: executor doesn't propagate exception from task that awaited a future (#1643 <https://github.com/ros2/rclpy/issues/1643>) (#1651 <https://github.com/ros2/rclpy/issues/1651>)
* Fix incorrect parameter names in docstrings (#1685 <https://github.com/ros2/rclpy/issues/1685>) (#1692 <https://github.com/ros2/rclpy/issues/1692>)
* Fix incorrect parameter names in docstrings (#1683 <https://github.com/ros2/rclpy/issues/1683>) (#1687 <https://github.com/ros2/rclpy/issues/1687>)
* Contributors: mergify[bot]
```
