### PR TITLE
rclpy: 7.1.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8988,7 +8988,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.1.11-1
+      version: 7.1.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.1.12-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.1.11-1`

## rclpy

```
* Fix incorrect parameter names in docstrings (#1685 <https://github.com/ros2/rclpy/issues/1685>) (#1693 <https://github.com/ros2/rclpy/issues/1693>)
* shutdown ThreadPoolExecutor in MultiThreadedExecutor. (backport #1309 <https://github.com/ros2/rclpy/issues/1309>) (#1670 <https://github.com/ros2/rclpy/issues/1670>)
* Fix incorrect parameter names in docstrings (#1683 <https://github.com/ros2/rclpy/issues/1683>) (#1688 <https://github.com/ros2/rclpy/issues/1688>)
* Contributors: mergify[bot]
```
