### PR TITLE
rclpy: 3.3.22-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9426,7 +9426,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.21-1
+      version: 3.3.22-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.22-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.3.21-1`

## rclpy

```
* Bugfix: executor doesn't propagate exception from task that awaited a future (backport #1643 <https://github.com/ros2/rclpy/issues/1643>) (#1653 <https://github.com/ros2/rclpy/issues/1653>)
* Fix incorrect parameter names in docstrings (backport #1685 <https://github.com/ros2/rclpy/issues/1685>) (#1695 <https://github.com/ros2/rclpy/issues/1695>)
* Fix incorrect parameter names in docstrings (backport #1683 <https://github.com/ros2/rclpy/issues/1683>) (#1689 <https://github.com/ros2/rclpy/issues/1689>)
* Correct typos (backport #1619 <https://github.com/ros2/rclpy/issues/1619>) (#1623 <https://github.com/ros2/rclpy/issues/1623>)
* Contributors: mergify[bot]
```
