### PR TITLE
ros2cli: 0.40.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8598,7 +8598,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.40.8-1
+      version: 0.40.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.40.9-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.40.8-1`

## ros2action

- No changes

## ros2cli

```
* Keep leading '~' unquoted in zsh completion. (#1279 <https://github.com/ros2/ros2cli/issues/1279>) (#1281 <https://github.com/ros2/ros2cli/issues/1281>) (#1284 <https://github.com/ros2/ros2cli/issues/1284>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

```
* fix non standard interface locations. (#1186 <https://github.com/ros2/ros2cli/issues/1186>) (#1283 <https://github.com/ros2/ros2cli/issues/1283>) (#1288 <https://github.com/ros2/ros2cli/issues/1288>)
* Contributors: mergify[bot]
```

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

```
* feat(ros2pkg): Install headers into subdirectory (#1280 <https://github.com/ros2/ros2cli/issues/1280>) (#1282 <https://github.com/ros2/ros2cli/issues/1282>)
* Contributors: mergify[bot]
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
