### PR TITLE
ros2cli: 0.32.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10257,7 +10257,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.32.11-1
+      version: 0.32.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.32.12-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.32.11-1`

## ros2action

- No changes

## ros2cli

```
* Keep leading '~' unquoted in zsh completion. (#1279 <https://github.com/ros2/ros2cli/issues/1279>) (#1281 <https://github.com/ros2/ros2cli/issues/1281>) (#1286 <https://github.com/ros2/ros2cli/issues/1286>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

```
* fix non standard interface locations. (#1186 <https://github.com/ros2/ros2cli/issues/1186>) (backport #1283 <https://github.com/ros2/ros2cli/issues/1283>) (#1290 <https://github.com/ros2/ros2cli/issues/1290>)
* Contributors: mergify[bot]
```

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
