### PR TITLE
olive-interfaces: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7369,6 +7369,23 @@ repositories:
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
       version: jazzy-devel
     status: developed
+  olive-interfaces:
+    doc:
+      type: git
+      url: https://github.com/olive-robotics/olive-ros2-interfaces.git
+      version: jazzy
+    release:
+      packages:
+      - olive_interfaces
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/olive-robotics/olive-ros2-interfaces-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/olive-robotics/olive-ros2-interfaces.git
+      version: jazzy
+    status: maintained
   ompl:
     doc:
       type: git


### PR DESCRIPTION
Releasing olive-interfaces 0.1.1-1 into ROS 2 Jazzy.

This adds the Jazzy release of `olive_interfaces` using:
- Source: https://github.com/olive-robotics/olive-ros2-interfaces
- Release repository: https://github.com/olive-robotics/olive-ros2-interfaces-release
- ROS distribution: Jazzy
- Ubuntu target: Noble

Generated with bloom.﻿
