### PR TITLE
elite_robots_simulation_gz: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2835,6 +2835,21 @@ repositories:
       url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_Description.git
       version: humble
     status: developed
+  elite_robots_simulation_gz:
+    doc:
+      type: git
+      url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_GZ_Simulation.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_GZ_Simulation-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_GZ_Simulation.git
+      version: humble
+    status: developed
   ess_imu_driver2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_robots_simulation_gz` to `1.0.0-1`:

- upstream repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_GZ_Simulation.git
- release repository: https://github.com/EliteRobots/Elite_Robots_CS_ROS2_GZ_Simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## elite_robots_simulation_gz

```
* Split the Gazebo simulation into a standalone ROS 2 package
* Rename the package to ``elite_robots_simulation_gz``
* Update the MoveIt configuration dependency to ``elite_robots_moveit_config``
* Add launch, controller configuration, and Gazebo trajectory-control files
* Add package documentation
* Contributors: Chen Shichao
```
