### PR TITLE
rviz: 16.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9485,7 +9485,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 16.0.2-1
+      version: 16.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `16.0.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `16.0.2-1`

## rviz2

```
* Removed Qt5 dependency (#1847 <https://github.com/ros2/rviz/issues/1847>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_common

```
* Removed Qt5 dependency (#1847 <https://github.com/ros2/rviz/issues/1847>)
* Fix implicit narrowing in tf2 time conversion (#1834 <https://github.com/ros2/rviz/issues/1834>)
* Cleanup headers (#1829 <https://github.com/ros2/rviz/issues/1829>)
* Optimize rclcpp headers (#1824 <https://github.com/ros2/rviz/issues/1824>)
* Fix tinyxml link error (#1817 <https://github.com/ros2/rviz/issues/1817>)
* Removed windows warning (#1819 <https://github.com/ros2/rviz/issues/1819>)
* Optimize include headers (#1799 <https://github.com/ros2/rviz/issues/1799>)
* Moved implementation to cpp (#1798 <https://github.com/ros2/rviz/issues/1798>)
* Contributors: Alejandro Hernández Cordero, ktyang512
```

## rviz_default_plugins

```
* Removed Qt5 dependency (#1847 <https://github.com/ros2/rviz/issues/1847>)
* Fix for every old swatch leaking a scene_node_ (#1843 <https://github.com/ros2/rviz/issues/1843>)
* Discover point cloud transports dynamically (#1842 <https://github.com/ros2/rviz/issues/1842>)
* Disable cursor-pixel readout in CameraDisplay (#1748 <https://github.com/ros2/rviz/issues/1748>)
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>)
* Cleanup headers (#1829 <https://github.com/ros2/rviz/issues/1829>)
* split rviz_default_plugins into per-family shared libraries (#1826 <https://github.com/ros2/rviz/issues/1826>)
* Optimize rclcpp headers (#1824 <https://github.com/ros2/rviz/issues/1824>)
* Optimize ogre headers (#1823 <https://github.com/ros2/rviz/issues/1823>)
* Optimize include headers (#1799 <https://github.com/ros2/rviz/issues/1799>)
* Moved implementation to cpp (#1798 <https://github.com/ros2/rviz/issues/1798>)
* Contributors: Alejandro Hernández Cordero, Arne Baeyens, Matthew Shields, Maurice Alexander Purnawan, Paul Erik Frivold
```

## rviz_ogre_vendor

```
* Removed unused variable to supress warning (#1812 <https://github.com/ros2/rviz/issues/1812>)
* Contributors: Miguel Angel Gonzalez Rodriguez
```

## rviz_rendering

```
* Removed Qt5 dependency (#1847 <https://github.com/ros2/rviz/issues/1847>)
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>)
* Cleanup headers (#1829 <https://github.com/ros2/rviz/issues/1829>)
* Optimize ogre headers (#1823 <https://github.com/ros2/rviz/issues/1823>)
* splitStringIntoTrimmedItems Function Handling Carriage Return and Form Feed Characters (#1709 <https://github.com/ros2/rviz/issues/1709>)
* Moved implementation to cpp (#1798 <https://github.com/ros2/rviz/issues/1798>)
* Support per-vertex mesh colors in the assimp loader (#1811 <https://github.com/ros2/rviz/issues/1811>)
* Contributors: Alejandro Hernández Cordero, Iori Yanokura, Paul Erik Frivold
```

## rviz_rendering_tests

```
* Removed Qt5 dependency (#1847 <https://github.com/ros2/rviz/issues/1847>)
* Support per-vertex mesh colors in the assimp loader (#1811 <https://github.com/ros2/rviz/issues/1811>)
* Contributors: Alejandro Hernández Cordero, Iori Yanokura
```

## rviz_visual_testing_framework

```
* Removed Qt5 dependency (#1847 <https://github.com/ros2/rviz/issues/1847>)
* Cleanup headers (#1829 <https://github.com/ros2/rviz/issues/1829>)
* Moved implementation to cpp (#1798 <https://github.com/ros2/rviz/issues/1798>)
* Contributors: Alejandro Hernández Cordero
```
