### PR TITLE
launch: 3.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3858,7 +3858,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.10.0-1
+      version: 3.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.10.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.10.0-1`

## launch

```
* Apply launch prefix without overwriting the logger name (#976 <https://github.com/ros2/launch/issues/976>)
* Add string strip substitution (#997 <https://github.com/ros2/launch/issues/997>)
* fix: parse respawn_max_retries YAML strings (#969 <https://github.com/ros2/launch/issues/969>)
* Fix LaunchService._is_idle() to consider active background tasks (#996 <https://github.com/ros2/launch/issues/996>)
* Contributors: Dylan Gallagher, Lidang Jiang, Mosiwon, William Woodall
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Add string strip substitution (#997 <https://github.com/ros2/launch/issues/997>)
* Contributors: Dylan Gallagher
```

## launch_yaml

```
* Add string strip substitution (#997 <https://github.com/ros2/launch/issues/997>)
* fix: parse respawn_max_retries YAML strings (#969 <https://github.com/ros2/launch/issues/969>)
* Contributors: Dylan Gallagher, Lidang Jiang
```
