### PR TITLE
rviz: 15.2.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9906,7 +9906,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.2.5-1
+      version: 15.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.2.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `15.2.5-1`

## rviz2

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Discover point cloud transports dynamically (#1842 <https://github.com/ros2/rviz/issues/1842>) (#1844 <https://github.com/ros2/rviz/issues/1844>)
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1838 <https://github.com/ros2/rviz/issues/1838>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1838 <https://github.com/ros2/rviz/issues/1838>)
* Support per-vertex mesh colors in the assimp loader (#1811 <https://github.com/ros2/rviz/issues/1811>) (#1813 <https://github.com/ros2/rviz/issues/1813>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

```
* Support per-vertex mesh colors in the assimp loader (#1811 <https://github.com/ros2/rviz/issues/1811>) (#1813 <https://github.com/ros2/rviz/issues/1813>)
* Contributors: mergify[bot]
```

## rviz_visual_testing_framework

- No changes
