### PR TITLE
rviz: 15.0.15-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9533,7 +9533,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.14-1
+      version: 15.0.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.15-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `15.0.14-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Discover point cloud transports dynamically (#1842 <https://github.com/ros2/rviz/issues/1842>) (#1845 <https://github.com/ros2/rviz/issues/1845>)
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1839 <https://github.com/ros2/rviz/issues/1839>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1839 <https://github.com/ros2/rviz/issues/1839>)
* Support per-vertex mesh colors in the assimp loader (#1811 <https://github.com/ros2/rviz/issues/1811>) (#1814 <https://github.com/ros2/rviz/issues/1814>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

```
* Support per-vertex mesh colors in the assimp loader (#1811 <https://github.com/ros2/rviz/issues/1811>) (#1814 <https://github.com/ros2/rviz/issues/1814>)
* Contributors: mergify[bot]
```

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
