### PR TITLE
rviz: 14.1.24-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11627,7 +11627,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.23-1
+      version: 14.1.24-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.24-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `14.1.23-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Discover point cloud transports dynamically (#1842 <https://github.com/ros2/rviz/issues/1842>) (#1846 <https://github.com/ros2/rviz/issues/1846>)
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1840 <https://github.com/ros2/rviz/issues/1840>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1840 <https://github.com/ros2/rviz/issues/1840>)
* Support per-vertex mesh colors in the assimp loader (backport #1811 <https://github.com/ros2/rviz/issues/1811>) (#1815 <https://github.com/ros2/rviz/issues/1815>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

```
* Support per-vertex mesh colors in the assimp loader (backport #1811 <https://github.com/ros2/rviz/issues/1811>) (#1815 <https://github.com/ros2/rviz/issues/1815>)
* Contributors: mergify[bot]
```

## rviz_visual_testing_framework

- No changes
