### PR TITLE
rviz: 11.2.29-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11772,7 +11772,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.28-1
+      version: 11.2.29-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.29-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `11.2.28-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1841 <https://github.com/ros2/rviz/issues/1841>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix memory leaks related to OdometryDisplay (#1833 <https://github.com/ros2/rviz/issues/1833>) (#1841 <https://github.com/ros2/rviz/issues/1841>)
* Support per-vertex mesh colors in the assimp loader (backport #1811 <https://github.com/ros2/rviz/issues/1811>) (#1816 <https://github.com/ros2/rviz/issues/1816>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

```
* Support per-vertex mesh colors in the assimp loader (backport #1811 <https://github.com/ros2/rviz/issues/1811>) (#1816 <https://github.com/ros2/rviz/issues/1816>)
* Contributors: mergify[bot]
```

## rviz_visual_testing_framework

- No changes
