### PR TITLE
olive-openrmf-fleet-adapter: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7572,6 +7572,23 @@ repositories:
       url: https://github.com/olive-robotics/olive-ros2-interfaces.git
       version: humble
     status: developed
+  olive-openrfm-fleet-adapter:
+    doc:
+      type: git
+      url: https://github.com/olive-robotics/olive-openrfm-fleet-adapter.git
+      version: humble
+    release:
+      packages:
+      - olive_openrmf_fleet_adapter
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/olive-robotics/olive-openrfm-fleet-adapter-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/olive-robotics/olive-openrfm-fleet-adapter.git
+      version: humble
+    status: developed
   omni_base_navigation:
     doc:
       type: git


### PR DESCRIPTION
Releasing olive-openrfm-fleet-adapter 0.0.1-1 into ROS 2 Humble.

Source:
https://github.com/olive-robotics/olive-openrfm-fleet-adapter

Release repository:
https://github.com/olive-robotics/olive-openrfm-fleet-adapter-release

Generated with bloom.﻿
