### PR TITLE
rmw_int2dds: 0.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10046,7 +10046,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_int2dds-release.git
-      version: 0.1.1-2
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/IntellectusCorp/rmw_int2dds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_int2dds` to `0.1.3-1`:

- upstream repository: https://github.com/IntellectusCorp/rmw_int2dds.git
- release repository: https://github.com/ros2-gbp/rmw_int2dds-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.1-2`

## int2dds_ffi_vendor

```
* Vendor the int2DDS FFI 0.1.3 release assets in place of 0.1.1. The published
  ``v0.1.3`` tarball ships the same ``int2dds-ffi.h`` as its git tag, so the
  version string identifies the ABI again; the ``v0.1.1`` assets had been
  rebuilt in place under one version and did not.
* Lower the glibc floor from 2.34 to 2.28 on x86_64 and aarch64, widening the
  set of hosts the prebuilt artifact runs on. armhf stays at 2.34 and the musl
  builds are unaffected.
* The soname is unchanged at ``libint2dds_ffi.so.0``.
* Contributors: Intellectus Corp.
```

## rmw_int2dds_cpp

```
* Build against int2DDS FFI 0.1.3, up from 0.1.1. Every FFI entry point this
  package calls kept its signature; 0.1.3 only adds new ones (filtered
  discovery snapshots, an endpoint discovery callback, and a writer data
  representation query).
* Seed a large UDP socket buffer in ``rmw_init`` so high-rate / large-message
  RELIABLE traffic no longer drops fragments.
* Own ``EventData`` in the publisher/subscription entities and free it on
  destroy, closing a per-event-type leak.
* Keep discovery reading when a sample outgrows the buffer, so a large discovery
  sample no longer blocks a participant.
* Report subscription matched via a cached event.
* Drop dead ``package.xml`` dependencies.
* Correct the ``ament_lint`` test-status count in the README.
* Poll the graph snapshot instead of waiting for it. ``kGraphSnapshotTimeout``
  drops to 0: a read leaves the instance in place, so an endpoint that has not
  arrived yet is picked up on the next pass and the 50 ms wait only burned the
  timeout.
* Honor ``ignore_local_publications`` in subscription readiness.
* Contributors: Intellectus Corp.
```
