### PR TITLE
olive-openrmf-fleet-adapter: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7386,6 +7386,23 @@ repositories:
       url: https://github.com/olive-robotics/olive-ros2-interfaces.git
       version: jazzy
     status: maintained
+  olive-openrfm-fleet-adapter:
+    doc:
+      type: git
+      url: https://github.com/olive-robotics/olive-openrfm-fleet-adapter.git
+      version: jazzy
+    release:
+      packages:
+      - olive_openrmf_fleet_adapter
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/olive-robotics/olive-openrfm-fleet-adapter-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/olive-robotics/olive-openrfm-fleet-adapter.git
+      version: jazzy
+    status: developed
   ompl:
     doc:
       type: git


### PR DESCRIPTION
Releasing olive-openrfm-fleet-adapter 0.0.2-1 into ROS 2 Jazzy.

Source:
https://github.com/olive-robotics/olive-openrfm-fleet-adapter

Release repository:
https://github.com/olive-robotics/olive-openrfm-fleet-adapter-release

Generated with bloom.﻿
