### PR TITLE
ros2_control: 6.10.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8284,7 +8284,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.9.0-1
+      version: 6.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.10.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.9.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix a few typos (#3567 <https://github.com/ros-controls/ros2_control/issues/3567>)
* Publish controller_manager activity on cleanup_controller (#3561 <https://github.com/ros-controls/ros2_control/issues/3561>)
* docs: Add documentation for utility scripts in controller_manager (#3175 <https://github.com/ros-controls/ros2_control/issues/3175>)
* Add test for --unload-on-kill spawner lock behavior (#3035 <https://github.com/ros-controls/ros2_control/issues/3035>)
* Relax assertions w.r.t. timing on CI runners (#3535 <https://github.com/ros-controls/ros2_control/issues/3535>)
* Contributors: Christoph Fröhlich, Dr. Denis, Naitik, Peter Mitrano (AR), ultrasage-danz
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

```
* Relax assertions w.r.t. timing on CI runners (#3535 <https://github.com/ros-controls/ros2_control/issues/3535>)
* Contributors: Christoph Fröhlich
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Fix view_controller_chains (#2026 <https://github.com/ros-controls/ros2_control/issues/2026>)
* Extend unload controller to unload all inactive controllers (#3466 <https://github.com/ros-controls/ros2_control/issues/3466>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
