### PR TITLE
ros2_control: 5.18.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8013,7 +8013,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.17.0-1
+      version: 5.18.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.18.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.17.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix a few typos (#3567 <https://github.com/ros-controls/ros2_control/issues/3567>) (#3569 <https://github.com/ros-controls/ros2_control/issues/3569>)
* Publish controller_manager activity on cleanup_controller (#3561 <https://github.com/ros-controls/ros2_control/issues/3561>) (#3564 <https://github.com/ros-controls/ros2_control/issues/3564>)
* docs: Add documentation for utility scripts in controller_manager (#3175 <https://github.com/ros-controls/ros2_control/issues/3175>) (#3551 <https://github.com/ros-controls/ros2_control/issues/3551>)
* Add test for --unload-on-kill spawner lock behavior (#3035 <https://github.com/ros-controls/ros2_control/issues/3035>) (#3540 <https://github.com/ros-controls/ros2_control/issues/3540>)
* Relax assertions w.r.t. timing on CI runners (#3535 <https://github.com/ros-controls/ros2_control/issues/3535>) (#3538 <https://github.com/ros-controls/ros2_control/issues/3538>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

```
* Relax assertions w.r.t. timing on CI runners (#3535 <https://github.com/ros-controls/ros2_control/issues/3535>) (#3538 <https://github.com/ros-controls/ros2_control/issues/3538>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Fix view_controller_chains (backport #2026 <https://github.com/ros-controls/ros2_control/issues/2026>) (#3589 <https://github.com/ros-controls/ros2_control/issues/3589>)
* Extend unload controller to unload all inactive controllers (#3466 <https://github.com/ros-controls/ros2_control/issues/3466>) (#3559 <https://github.com/ros-controls/ros2_control/issues/3559>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
