### PR TITLE
ros2_control: 4.48.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9917,7 +9917,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.47.0-1
+      version: 4.48.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.48.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.47.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix a few typos (#3567 <https://github.com/ros-controls/ros2_control/issues/3567>) (#3568 <https://github.com/ros-controls/ros2_control/issues/3568>)
* Publish controller_manager activity on cleanup_controller (#3561 <https://github.com/ros-controls/ros2_control/issues/3561>) (#3563 <https://github.com/ros-controls/ros2_control/issues/3563>)
* docs: Add documentation for utility scripts in controller_manager (#3175 <https://github.com/ros-controls/ros2_control/issues/3175>) (#3550 <https://github.com/ros-controls/ros2_control/issues/3550>)
* Add test for --unload-on-kill spawner lock behavior (#3035 <https://github.com/ros-controls/ros2_control/issues/3035>) (#3539 <https://github.com/ros-controls/ros2_control/issues/3539>)
* Relax assertions w.r.t. timing on CI runners (#3535 <https://github.com/ros-controls/ros2_control/issues/3535>) (#3537 <https://github.com/ros-controls/ros2_control/issues/3537>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

```
* Relax assertions w.r.t. timing on CI runners (#3535 <https://github.com/ros-controls/ros2_control/issues/3535>) (#3537 <https://github.com/ros-controls/ros2_control/issues/3537>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Fix view_controller_chains (backport #2026 <https://github.com/ros-controls/ros2_control/issues/2026>) (#3588 <https://github.com/ros-controls/ros2_control/issues/3588>)
* Extend unload controller to unload all inactive controllers (#3466 <https://github.com/ros-controls/ros2_control/issues/3466>) (#3558 <https://github.com/ros-controls/ros2_control/issues/3558>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
