### PR TITLE
ros2_control: 2.54.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10305,7 +10305,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.54.0-1
+      version: 2.54.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.54.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.54.0-1`

## controller_interface

- No changes

## controller_manager

```
* Refactor launch test to use launch substitutions instead of os (#3142 <https://github.com/ros-controls/ros2_control/issues/3142>) (#3523 <https://github.com/ros-controls/ros2_control/issues/3523>)
* Add tests for launch_utils of controller manager (#2768 <https://github.com/ros-controls/ros2_control/issues/2768>) (#3509 <https://github.com/ros-controls/ros2_control/issues/3509>)
* document Ubuntu realtime kernel on Raspberry Pi (#3397 <https://github.com/ros-controls/ros2_control/issues/3397>) (#3398 <https://github.com/ros-controls/ros2_control/issues/3398>)
* Wait to terminate test until spawner exits (#3373 <https://github.com/ros-controls/ros2_control/issues/3373>) (#3383 <https://github.com/ros-controls/ros2_control/issues/3383>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Fix view_controller_chains (backport #2026 <https://github.com/ros-controls/ros2_control/issues/2026>) (#3587 <https://github.com/ros-controls/ros2_control/issues/3587>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* rqt_cm: Robustify test and fix shutdown races (backport #3396 <https://github.com/ros-controls/ros2_control/issues/3396>) (#3463 <https://github.com/ros-controls/ros2_control/issues/3463>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
