### PR TITLE
rmw_int2dds: 0.1.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8067,11 +8067,10 @@ repositories:
       packages:
       - int2dds_ffi_vendor
       - rmw_int2dds_cpp
-      - rmw_int2dds_validation
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_int2dds-release.git
-      version: 0.1.1-1
+      version: 0.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_int2dds` to `0.1.3-1`:

- upstream repository: https://github.com/IntellectusCorp/rmw_int2dds.git
- release repository: https://github.com/ros2-gbp/rmw_int2dds-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.1-1`

## int2dds_ffi_vendor

```
* Vendor the int2DDS FFI 0.1.3 release assets in place of 0.1.1. The published
  ``v0.1.3`` tarball ships the same ``int2dds-ffi.h`` as its git tag, so the
  version string identifies the ABI again; the ``v0.1.1`` assets had been
  rebuilt in place under one version and did not.
* Lower the glibc floor from 2.34 to 2.28 on x86_64 and aarch64, widening the
  set of hosts the prebuilt artifact runs on. armhf stays at 2.34 and the musl
  builds are unaffected.
* The soname is unchanged at ``libint2dds_ffi.so.0``.
* Contributors: Intellectus Corp.
```

## rmw_int2dds_cpp

```
* Build against int2DDS FFI 0.1.3, up from 0.1.1. Every FFI entry point this
  package calls kept its signature; 0.1.3 only adds new ones (filtered
  discovery snapshots, an endpoint discovery callback, and a writer data
  representation query).
* No other source changes.
* Contributors: Intellectus Corp.
```
