### PR TITLE
moveit_task_constructor: 0.1.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   debian:
@@ -4965,7 +4965,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_task_constructor-release.git
-      version: 0.1.5-1
+      version: 0.1.8-1
     source:
       type: git
       url: https://github.com/moveit/moveit_task_constructor.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4966,10 +4966,6 @@ repositories:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_task_constructor-release.git
       version: 0.1.8-1
-    source:
-      type: git
-      url: https://github.com/moveit/moveit_task_constructor.git
-      version: ros2
     status: maintained
   moveit_visual_tools:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_task_constructor` to `0.1.8-1`:

- upstream repository: https://github.com/moveit/moveit_task_constructor.git
- release repository: https://github.com/ros2-gbp/moveit_task_constructor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.5-1`

## moveit_task_constructor_capabilities

```
* Fix integration test (#760 <https://github.com/moveit/moveit_task_constructor/issues/760>)
* Contributors: ktyang512
```

## moveit_task_constructor_core

```
* clang-tidy fixes
* Fix ordering of pybind11 and py-binding-tools
* Fix integration test (#760 <https://github.com/moveit/moveit_task_constructor/issues/760>)
* Contributors: Robert Haschke, ktyang512
```

## moveit_task_constructor_demo

- No changes

## moveit_task_constructor_msgs

- No changes

## moveit_task_constructor_visualization

- No changes

## rviz_marker_tools

- No changes
