### PR TITLE
realtime_tools: 5.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7131,7 +7131,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 5.2.0-2
+      version: 5.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `5.3.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.2.0-2`

## realtime_tools

```
* feat: create publisher internally in RealtimePublisher (#573 <https://github.com/ros-controls/realtime_tools/issues/573>)
* print async thread pinned cores (#551 <https://github.com/ros-controls/realtime_tools/issues/551>)
* Add configure_sched_rr() for SCHED_RR scheduling policy (#513 <https://github.com/ros-controls/realtime_tools/issues/513>)
* package.xml: correct license to a valid SPDX (#552 <https://github.com/ros-controls/realtime_tools/issues/552>)
* Add thread naming in async function handler (#550 <https://github.com/ros-controls/realtime_tools/issues/550>)
* Apply CMP0167 also for exported dependencies (#539 <https://github.com/ros-controls/realtime_tools/issues/539>)
* Fix CMP0167 and remove FindBoost (#531 <https://github.com/ros-controls/realtime_tools/issues/531>)
* Bump C++ version to C++20 (#520 <https://github.com/ros-controls/realtime_tools/issues/520>)
* Contributors: Christoph Fröhlich, Jan Vermaete, Nikola Banović, Souri Rishik, Suresh Kondepudi
```
