### PR TITLE
realtime_tools: 4.9.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7311,7 +7311,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.8.0-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.9.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.8.0-1`

## realtime_tools

```
* feat: create publisher internally in RealtimePublisher (backport #573 <https://github.com/ros-controls/realtime_tools/issues/573>) (#575 <https://github.com/ros-controls/realtime_tools/issues/575>)
* print async thread pinned cores (backport #551 <https://github.com/ros-controls/realtime_tools/issues/551>) (#568 <https://github.com/ros-controls/realtime_tools/issues/568>)
* Add configure_sched_rr() for SCHED_RR scheduling policy (backport #513 <https://github.com/ros-controls/realtime_tools/issues/513>) (#563 <https://github.com/ros-controls/realtime_tools/issues/563>)
* Add thread renaming in async function handler (backport #550 <https://github.com/ros-controls/realtime_tools/issues/550>) (#559 <https://github.com/ros-controls/realtime_tools/issues/559>)
* package.xml: correct license to a valid SPDX (backport #552 <https://github.com/ros-controls/realtime_tools/issues/552>) (#555 <https://github.com/ros-controls/realtime_tools/issues/555>)
* Apply CMP0167 also for exported dependencies (backport #539 <https://github.com/ros-controls/realtime_tools/issues/539>) (#541 <https://github.com/ros-controls/realtime_tools/issues/541>)
* Fix CMP0167 and remove FindBoost (backport #531 <https://github.com/ros-controls/realtime_tools/issues/531>) (#534 <https://github.com/ros-controls/realtime_tools/issues/534>)
* Contributors: mergify[bot]
```
