### PR TITLE
realtime_tools: 3.12.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9149,7 +9149,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.11.0-1
+      version: 3.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.12.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.11.0-1`

## realtime_tools

```
* feat: create publisher internally in RealtimePublisher (backport #573 <https://github.com/ros-controls/realtime_tools/issues/573>) (#574 <https://github.com/ros-controls/realtime_tools/issues/574>)
* print async thread pinned cores (backport #551 <https://github.com/ros-controls/realtime_tools/issues/551>) (#567 <https://github.com/ros-controls/realtime_tools/issues/567>)
  print async thread pinned cores (#551 <https://github.com/ros-controls/realtime_tools/issues/551>)
* Add configure_sched_rr() for SCHED_RR scheduling policy (backport #513 <https://github.com/ros-controls/realtime_tools/issues/513>) (#562 <https://github.com/ros-controls/realtime_tools/issues/562>)
* Add thread renaming in async function handler (backport #550 <https://github.com/ros-controls/realtime_tools/issues/550>) (#558 <https://github.com/ros-controls/realtime_tools/issues/558>)
* package.xml: correct license to a valid SPDX (backport #552 <https://github.com/ros-controls/realtime_tools/issues/552>) (#554 <https://github.com/ros-controls/realtime_tools/issues/554>)
* Apply CMP0167 also for exported dependencies (backport #539 <https://github.com/ros-controls/realtime_tools/issues/539>) (#540 <https://github.com/ros-controls/realtime_tools/issues/540>)
* Fix CMP0167 and remove FindBoost (backport #531 <https://github.com/ros-controls/realtime_tools/issues/531>) (#533 <https://github.com/ros-controls/realtime_tools/issues/533>)
* Contributors: mergify[bot]
```
