### PR TITLE
realtime_tools: 2.15.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9554,7 +9554,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.15.0-1
+      version: 2.15.1-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.15.1-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.0-1`

## realtime_tools

```
* package.xml: correct license to a valid SPDX (backport #552 <https://github.com/ros-controls/realtime_tools/issues/552>) (#553 <https://github.com/ros-controls/realtime_tools/issues/553>)
* Contributors: dependabot[bot], mergify[bot]
```
