### PR TITLE
image_common: 7.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3372,7 +3372,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 7.0.3-1
+      version: 7.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `7.0.4-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.0.3-1`

## camera_calibration_parsers

```
* Optimize includes (#430 <https://github.com/ros-perception/image_common/issues/430>)
* camera_calibration_parsers: allow reading read-only INI files (#431 <https://github.com/ros-perception/image_common/issues/431>)
* Contributors: Alejandro Hernández Cordero, ktyang
```

## camera_info_manager

```
* Optimize includes (#430 <https://github.com/ros-perception/image_common/issues/430>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Optimize includes (#430 <https://github.com/ros-perception/image_common/issues/430>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_py

```
* Optimize includes (#430 <https://github.com/ros-perception/image_common/issues/430>)
* Contributors: Alejandro Hernández Cordero
```
