### PR TITLE
sdformat_vendor: 0.0.14-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11791,7 +11791,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.0.11-1
+      version: 0.0.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.0.14-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.11-1`

## sdformat_vendor

```
* Enable Python bindings (#29 <https://github.com/gazebo-release/sdformat_vendor/issues/29>)
  * Enable Python bindings
  * Rerun gz_vendor
  ---------
* Contributors: Addisu Z. Taddese
```
