### PR TITLE
point_cloud_transport: 6.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6277,7 +6277,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 6.0.2-1
+      version: 6.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `6.0.3-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.2-1`

## point_cloud_transport

```
* Optimize includes (#191 <https://github.com/ros-perception/point_cloud_transport/issues/191>)
* Removed manifest.cpp and moved to cpp file (#192 <https://github.com/ros-perception/point_cloud_transport/issues/192>)
* Contributors: Alejandro Hernández Cordero
```

## point_cloud_transport_py

```
* Optimize includes (#191 <https://github.com/ros-perception/point_cloud_transport/issues/191>)
* Contributors: Alejandro Hernández Cordero
```
