### PR TITLE
gz_msgs_vendor: 0.0.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4001,7 +4001,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_msgs_vendor` to `0.0.8-1`:

- upstream repository: https://github.com/gazebo-release/gz_msgs_vendor.git
- release repository: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.7-1`

## gz_msgs_vendor

```
* Enable Python bindings (#22 <https://github.com/gazebo-release/gz_msgs_vendor/issues/22>)
  * Enable Python bindings
  * Rerun gz_vendor
  ---------
* Contributors: Addisu Z. Taddese
```
