### PR TITLE
autoware_internal_msgs: 1.16.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1085,7 +1085,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.15.0-1
+      version: 1.16.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.16.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.15.0-1`

## autoware_internal_debug_msgs

- No changes

## autoware_internal_localization_msgs

- No changes

## autoware_internal_metric_msgs

- No changes

## autoware_internal_msgs

- No changes

## autoware_internal_perception_msgs

```
* feat(autoware_internal_perception_msgs): deprecate SegmentationMask.msg (#93 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/93>)
  SegmentationMask.msg was added in 1.2.0 (#29 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/29>) for the RTMDet instance
  segmentation effort in autoware_universe. That effort was abandoned:
  autowarefoundation/autoware_universe#8165 <https://github.com/autowarefoundation/autoware_universe/issues/8165> was never merged and the parent issue
  autowarefoundation/autoware_universe#7235 <https://github.com/autowarefoundation/autoware_universe/issues/7235> is closed as not planned. The one
  consumer candidate, autowarefoundation/autoware_universe#9482 <https://github.com/autowarefoundation/autoware_universe/issues/9482>, is also closed.
  Nothing in autoware_universe or autoware_core publishes or subscribes to this
  message today, so mark it deprecated with a leading comment banner. rosidl has
  no message-level deprecation annotation, so a comment naming the release is the
  only available mechanism; this follows ros-controls/control_msgs and
  ros2/common_interfaces.
  The message itself is kept. It is the only entry in this package's msg_files,
  so removing it would mean retiring the whole package, and any out-of-tree
  consumer should keep building.
* Contributors: Mete Fatih Cırıt
```

## autoware_internal_planning_msgs

- No changes
