### PR TITLE
qt_gui_core: 3.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   debian:
@@ -6674,7 +6674,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `3.0.3-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-1`

## qt_dotgraph

- No changes

## qt_gui

```
* Removed Qt5 (#345 <https://github.com/ros-visualization/qt_gui_core/issues/345>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Removed Qt5 (#345 <https://github.com/ros-visualization/qt_gui_core/issues/345>)
* optimize include headers (#344 <https://github.com/ros-visualization/qt_gui_core/issues/344>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_py_common

- No changes
