### PR TITLE
rqt_bag: 2.3.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   debian:
@@ -8966,7 +8966,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.3.4-1
+      version: 2.3.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.3.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.3.4-1`

## rqt_bag

```
* Removed Qt5 support (#215 <https://github.com/ros-visualization/rqt_bag/issues/215>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_bag_plugins

```
* Removed Qt5 support (#215 <https://github.com/ros-visualization/rqt_bag/issues/215>)
* Contributors: Alejandro Hernández Cordero
```
