### PR TITLE
ur_client_library: 2.15.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10855,7 +10855,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.14.1-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.15.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.14.1-1`

## ur_client_library

```
* Robot api 10.14 (#549 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/549>)
* Fix spline point velocity and acceleration precision (#559 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/559>)
* MotionTarget helpers (#558 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/558>)
* [CI] Support running PolyScope X robot in remote control mode in CI (#553 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/553>)
* [CI] Update downstream branch for lyrical (#555 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/555>)
* [CI] Add exclude rule for stackoverflow (#557 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/557>)
* [CI] Separate standalone instruction executor test into its own file (#554 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/554>)
* Contributors: Felix Exner, Hasan Amin, URJala
```
