### PR TITLE
Add grasp_synergy_adapter source entry to Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3731,6 +3731,12 @@ repositories:
       url: https://github.com/PickNikRobotics/graph_msgs.git
       version: ros2
     status: maintained
+  grasp_synergy_adapter:
+    source:
+      type: git
+      url: https://github.com/shkwon98/grasp_synergy_adapter.git
+      version: main
+    status: maintained
   grasping_msgs:
     doc:
       type: git


### PR DESCRIPTION
This PR adds `grasp_synergy_adapter` to ROS 2 Jazzy as a source entry.

This is a source-only addition for initial package naming review before
creating the corresponding release repository and performing the first
Bloom release.

## Package name

grasp_synergy_adapter

## Package upstream source

https://github.com/shkwon98/grasp_synergy_adapter

## Purpose

`grasp_synergy_adapter` maps low-dimensional grasp commands to configurable
multi-joint hand trajectories. It provides standard JointTrajectoryController-
compatible endpoints and supports different robot hands through YAML
configuration without vendor-specific code.

# Please Add This Package to be indexed in the rosdistro.

Jazzy

# The source is here:

https://github.com/shkwon98/grasp_synergy_adapter

# Checks

- [x] All packages have a declared license in the package.xml
- [x] This repository has a LICENSE file
- [x] This package is expected to build on the submitted rosdistro