### PR TITLE
robot_state_publisher: 3.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7815,7 +7815,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.6.1-1
+      version: 3.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.6.2-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.6.1-1`

## robot_state_publisher

```
* granular rclcpp/rclcpp.hpp and include what you use (#254 <https://github.com/ros/robot_state_publisher/issues/254>)
* Run tests with RMW isolation
* Contributors: Alejandro Hernández Cordero, Yadunund Vijay, yadunund
```
