### PR TITLE
robot_state_publisher: 3.5.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8180,7 +8180,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.5.5-3
+      version: 3.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.5.6-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.5.5-3`

## robot_state_publisher

```
* Merge pull request #252 <https://github.com/ros/robot_state_publisher/issues/252> from ros/mergify/bp/lyrical/pr-251
* Run tests with RMW isolation
* Contributors: Yadunund Vijay, yadunund
```
