### PR TITLE
robot_state_publisher: 3.4.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   debian:
@@ -7906,7 +7906,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.4.3-1
+      version: 3.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.4.4-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.4.3-1`

## robot_state_publisher

```
* Merge pull request #253 <https://github.com/ros/robot_state_publisher/issues/253> from ros/mergify/bp/kilted/pr-251
* Run tests with RMW isolation
* Add functionality to read description from a topic instead of a parameter (#234 <https://github.com/ros/robot_state_publisher/issues/234>) (#244 <https://github.com/ros/robot_state_publisher/issues/244>)
* Contributors: Guillaume Doisy, Yadunund Vijay, yadunund
```
