### PR TITLE
gz_cmake_vendor: 0.3.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2977,7 +2977,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-      version: 0.3.5-1
+      version: 0.3.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_cmake_vendor` to `0.3.6-1`:

- upstream repository: https://github.com/gazebo-release/gz_cmake_vendor.git
- release repository: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.5-1`

## gz_cmake_vendor

```
* Revert "Enable Python bindings (#30 <https://github.com/gazebo-release/gz_cmake_vendor/issues/30>)" (#32 <https://github.com/gazebo-release/gz_cmake_vendor/issues/32>)
  This reverts commit 1568cd6c476cbe275ecbfed9111bcb6f522ca40e.
* Contributors: Addisu Z. Taddese
```
