### PR TITLE
gz_tools_vendor: 0.1.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3219,7 +3219,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_tools_vendor-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_tools_vendor` to `0.1.6-1`:

- upstream repository: https://github.com/gazebo-release/gz_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_tools_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.5-1`

## gz_tools_vendor

```
* Revert "Enable Python bindings (#18 <https://github.com/gazebo-release/gz_tools_vendor/issues/18>)" (#20 <https://github.com/gazebo-release/gz_tools_vendor/issues/20>)
  This reverts commit 80dc2b667402e5d7e202f61b9c778022af000149.
* Contributors: Addisu Z. Taddese
```
