### PR TITLE
gz_plugin_vendor: 0.2.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3137,7 +3137,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_plugin_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_plugin_vendor.git
- release repository: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.4-1`

## gz_plugin_vendor

```
* Revert "Enable Python bindings (#12 <https://github.com/gazebo-release/gz_plugin_vendor/issues/12>)" (#14 <https://github.com/gazebo-release/gz_plugin_vendor/issues/14>)
  * Revert "Enable Python bindings (#12 <https://github.com/gazebo-release/gz_plugin_vendor/issues/12>)"
  This reverts commit cc25546caf609369fb1267f295414df7d827ab2d.
  * Rerun gz_vendor
  ---------
* Contributors: Addisu Z. Taddese
```
