### PR TITLE
gz_common_vendor: 0.2.10-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2993,7 +2993,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.2.9-1
+      version: 0.2.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.2.10-1`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.9-1`

## gz_common_vendor

```
* Revert "Enable Python bindings (#37 <https://github.com/gazebo-release/gz_common_vendor/issues/37>)" (#39 <https://github.com/gazebo-release/gz_common_vendor/issues/39>)
  This reverts commit 3eb5a453933bfa1c247ca458ba343d9ed21c5990.
* Contributors: Addisu Z. Taddese
```
