### PR TITLE
gz_fuel_tools_vendor: 0.2.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3025,7 +3025,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_fuel_tools_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.4-1`

## gz_fuel_tools_vendor

```
* Revert "Enable Python bindings (#14 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/14>)" (#16 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/16>)
  * Revert "Enable Python bindings (#14 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/14>)"
  This reverts commit 386e4f1ccd5d711636596594c907dd4452d3d0d5.
  * Rerun gz_vendor
  ---------
* Contributors: Addisu Z. Taddese
```
