### PR TITLE
gz_physics_vendor: 0.2.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3121,7 +3121,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_physics_vendor-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_physics_vendor` to `0.2.6-1`:

- upstream repository: https://github.com/gazebo-release/gz_physics_vendor.git
- release repository: https://github.com/ros2-gbp/gz_physics_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.5-1`

## gz_physics_vendor

```
* Revert "Enable Python bindings (#29 <https://github.com/gazebo-release/gz_physics_vendor/issues/29>)" (#32 <https://github.com/gazebo-release/gz_physics_vendor/issues/32>)
  This reverts commit c85e77d3e0f66d03c58fe616baa73c17957867ab.
* Contributors: Addisu Z. Taddese
```
