### PR TITLE
gz_rendering_vendor: 0.2.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3153,7 +3153,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
-      version: 0.2.7-1
+      version: 0.2.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_rendering_vendor` to `0.2.8-1`:

- upstream repository: https://github.com/gazebo-release/gz_rendering_vendor.git
- release repository: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.7-1`

## gz_rendering_vendor

```
* Revert "Enable Python bindings (#23 <https://github.com/gazebo-release/gz_rendering_vendor/issues/23>)" (#25 <https://github.com/gazebo-release/gz_rendering_vendor/issues/25>)
  * Revert "Enable Python bindings (#23 <https://github.com/gazebo-release/gz_rendering_vendor/issues/23>)"
  This reverts commit 44b1b7c47f1e0f76f86ef33fd2058355f2b9d54e.
  * Rerun gz_vendor
  ---------
* Contributors: Addisu Z. Taddese
```
