### PR TITLE
gz_gui_vendor: 0.2.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3041,7 +3041,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_gui_vendor` to `0.2.4-1`:

- upstream repository: https://github.com/gazebo-release/gz_gui_vendor.git
- release repository: https://github.com/ros2-gbp/gz_gui_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.3-1`

## gz_gui_vendor

```
* Revert "Enable Python bindings (#13 <https://github.com/gazebo-release/gz_gui_vendor/issues/13>)" (#15 <https://github.com/gazebo-release/gz_gui_vendor/issues/15>)
  * Revert "Enable Python bindings (#13 <https://github.com/gazebo-release/gz_gui_vendor/issues/13>)"
  This reverts commit 57ee2f8368907282b876d8c7dc630548be1ce415.
  * Rerun gz_vendor
  ---------
* Contributors: Addisu Z. Taddese
```
