### PR TITLE
gz_sensors_vendor: 0.2.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3187,7 +3187,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.4-1`

## gz_sensors_vendor

```
* Revert "Enable Python bindings (#18 <https://github.com/gazebo-release/gz_sensors_vendor/issues/18>)" (#21 <https://github.com/gazebo-release/gz_sensors_vendor/issues/21>)
  * Revert "Enable Python bindings (#18 <https://github.com/gazebo-release/gz_sensors_vendor/issues/18>)"
  This reverts commit d7145c7eef7082ff3df5b60509a812ded9d22975.
  * Rerun gz_vendor
  ---------
* Contributors: Addisu Z. Taddese
```
