### PR TITLE
gz_launch_vendor: 0.2.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3057,7 +3057,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_launch_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_launch_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_launch_vendor.git
- release repository: https://github.com/ros2-gbp/gz_launch_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.4-1`

## gz_launch_vendor

```
* Revert "Enable Python bindings (#14 <https://github.com/gazebo-release/gz_launch_vendor/issues/14>)" (#16 <https://github.com/gazebo-release/gz_launch_vendor/issues/16>)
  This reverts commit 8d618b42e5696a8b5a4770034abc997449992130.
* Contributors: Addisu Z. Taddese
```
