### PR TITLE
nodl: 2.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5791,12 +5791,19 @@ repositories:
       version: main
     release:
       packages:
-      - nodl_python
+      - ament_nodl
+      - nodl
+      - nodl_common_interfaces
+      - nodl_conformance
+      - nodl_docgen
+      - nodl_generator_cpp
+      - nodl_observe
+      - nodl_schema
       - ros2nodl
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
-      version: 0.3.1-6
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/nodl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodl` to `2.0.2-1`:

- upstream repository: https://github.com/ros-tooling/nodl.git
- release repository: https://github.com/ros2-gbp/nodl-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.1-6`

## ament_nodl

- No changes

## nodl

```
* fix: nodl_docgen CI and fixes (#149 <https://github.com/ros-tooling/nodl/issues/149>)
* Contributors: Emerson Knapp
```

## nodl_common_interfaces

- No changes

## nodl_conformance

- No changes

## nodl_docgen

```
* fix: nodl_docgen CI and fixes (#149 <https://github.com/ros-tooling/nodl/issues/149>)
* Contributors: Emerson Knapp
```

## nodl_generator_cpp

- No changes

## nodl_observe

- No changes

## nodl_schema

- No changes

## ros2nodl

- No changes
