### PR TITLE
web_tf_editor: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -13905,6 +13905,12 @@ repositories:
       url: https://github.com/WATonomous/wato_monorepo.git
       version: main
     status: developed
+  web_tf_editor:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/farshad-heravi/web_tf_editor.git
+      version: 0.1.1-1
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_tf_editor` to `0.1.1-1`:

- upstream repository: https://github.com/farshad-heravi/web_tf_editor.git
- release repository: https://github.com/farshad-heravi/web_tf_editor.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## web_tf_editor

```
* Deselect frame on right-click in empty space
* Dim non-selected frames and highlight the selected frame's label in the 3D view
* Add D shortcut to duplicate the selected frame, offset along its X axis
* Add Onshape-style view cube for snapping the camera to standard/isometric views
* Default robot_description source to the /robot_description topic instead of the ROS parameter
* Restyle transform gizmo as a MoveIt/RViz-style interactive marker (arrows + rings shown together)
* Add multi-distro CI (Jazzy, Humble, Rolling) with private-repo clone auth and a web bundle build check
* Render TF axes with bold fat lines instead of 1px hairlines
* Initial commit: web_tf_editor, a browser-based rviz-like TF frame editor over rosbridge (ROS 2 Jazzy)
* Contributors: farshad-heravi
```
