### PR TITLE
mola_imu_preintegration: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -6086,7 +6086,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.17.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `2.0.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.17.1-1`

## mola_imu_preintegration

```
* Add on-manifold IMU preintegration (``ImuPreintegrator``) and sliding-window
  gravity-in-map estimation (``MapGravityEstimator``), with realistic default
  MEMS noise densities for ``ImuIntegrationParams`` (#12 <https://github.com/MOLAorg/mola_imu_preintegration/issues/12>)
* ``MapGravityEstimator``: report gravity-estimate accuracy via
  pitch/roll sigma instead of gating convergence on a fixed threshold
* Fix O(size) pruning scan in ``LocalVelocityBuffer``, making it amortized
  O(deleted) so long-retention, high-rate buffers no longer stall the
  consumer thread (#13 <https://github.com/MOLAorg/mola_imu_preintegration/issues/13>)
* ``ImuInitialCalibrator``: readiness is now based on a configurable time
  window plus an optional accelerometer-direction dispersion gate, instead
  of a plain sample count that made readiness rate-dependent; both are
  opt-in and preserve prior behavior by default (#14 <https://github.com/MOLAorg/mola_imu_preintegration/issues/14>)
* Drop degenerate (all-zero or NaN) orientation quaternions in
  ``ImuInitialCalibrator``, falling back to gravity-based accelerometer
  leveling instead of aborting (#11 <https://github.com/MOLAorg/mola_imu_preintegration/issues/11>)
* fix lyrical badges
* Contributors: Jose Luis Blanco-Claraco
```
