### PR TITLE
mp2p_icp: 2.14.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -4995,7 +4995,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.13.1-1
+      version: 2.14.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.14.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.13.1-1`

## mp2p_icp

- No changes

## mp2p_icp_core

```
* Point matchers (Matcher_Points_DistanceThreshold, Matcher_Points_Blend):
  fixed a nondeterministic pairing order caused by parallel reduction depending
  on TBB thread scheduling; the correspondence list is now a function of the
  input alone, regardless of thread count.
* Solver_GaussNewton: the robust kernel now receives a whitened residual (using
  the existing pair weight as the whitening factor) instead of a raw metric or
  Mahalanobis norm, so robustKernelParam means the same number of sigmas for
  every pair type. Bit-identical for pipelines using default weights.
* GravityPrior: report the fraction of the final rotational information the
  prior actually contributed, via new gravity_information_share field in
  OptimalTF_Result and Results (negative when no prior was given); this
  value is now also persisted across serialization (Results format v1) and
  reset at the start of each solve.
* New FilterPlanePatches: extracts large planar patches (equation, centroid,
  area, point count) into metric_map_t::planes, complementing
  FilterEdgesPlanes' per-point labeling. Deterministic greedy extraction seeded
  by per-point normals. metric_map_t serialization goes to v6.
* FilterVoxelReduction: made the downsampling order-independent (selection no
  longer depends on input point order) and tightened bounds on range_min and
  normal_agreement_deg.
* Contributors: Jose Luis Blanco-Claraco
```

## mp2p_icp_viz

- No changes
