### PR TITLE
robstride_ros2: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10241,7 +10241,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robstride_ros2-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/s2015-turtle/robstride_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robstride_ros2` to `0.2.0-1`:

- upstream repository: https://github.com/s2015-turtle/robstride_ros2.git
- release repository: https://github.com/ros2-gbp/robstride_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.2-1`

## robstride_driver

```
* Add CAN traffic metrics and human-readable motor and transport diagnostics.
* Report motor mode, temperature, faults, feedback age, and recovery attempts.
* Reduce transport contention during control updates and propagate persistent
  transmit-path failures.
* Add virtual CAN transport and fake-motor lifecycle integration tests.
* Centralize RS00-RS06 and EL05 protocol ranges in the motor profile registry.
* Contributors: Yamato.K
```

## robstride_examples

```
* Forward the existing motor-profile Xacro include to robstride_ros2_control,
  preserving macro names and arguments.
* Remove duplicated protocol ranges from the example package.
* Verify model selection, explicit gains, and operational limits in Xacro tests.
* Contributors: Yamato.K
```

## robstride_ros2

```
* Synchronize all packages at 0.2.0 for diagnostics, transport health,
  production-owned motor profiles, and virtual CAN integration coverage.
* Preserve the aggregate installation entry point and existing plugin name.
* Contributors: Yamato.K
```

## robstride_ros2_control

```
* Resolve known motor models from the production driver profile registry.
* Reject unknown model names and conflicting numeric profile overrides while
  preserving validated custom and legacy explicit-limit configurations.
* Install production-owned motor-profile Xacro helpers and declare their
  Xacro runtime dependency.
* Propagate persistent transport failures through the hardware interface.
* Expanded profile macros now emit a model name instead of numeric ranges;
  use the updated driver together with the updated Xacro helpers.
* Contributors: Yamato.K
```
