### PR TITLE
jsk_common_msgs: 5.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3813,7 +3813,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/tork-a/jsk_common_msgs-release.git
-      version: 5.0.1-3
+      version: 5.0.2-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `5.0.2-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.0.1-3`

## posedetection_msgs

```
* Fix message_filters::Subscriber API compatibility between Jazzy and Kilted+,
  and update message_filters includes to .hpp for ROS2 (#36 <https://github.com/jsk-ros-pkg/jsk_common_msgs/issues/36>)
* Contributors: Kei Okada
```
