### PR TITLE
rqt_lifecycle_manager: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11197,7 +11197,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_lifecycle_manager-release.git
-      version: 0.1.0-2
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ajtudela/rqt_lifecycle_manager.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_lifecycle_manager` to `0.2.0-1`:

- upstream repository: https://github.com/ajtudela/rqt_lifecycle_manager
- release repository: https://github.com/ros2-gbp/rqt_lifecycle_manager-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.0-2`

## rqt_lifecycle_manager

- No changes
