### PR TITLE
sicks300_ros2: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   debian:
@@ -9728,6 +9728,16 @@ repositories:
       type: git
       url: https://github.com/ajtudela/sicks300_ros2.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sicks300_ros2-release.git
+      version: 1.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ajtudela/sicks300_ros2.git
+      version: rolling
     status: maintained
   simple_actions:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicks300_ros2` to `1.4.0-1`:

- upstream repository: https://github.com/ajtudela/sicks300_ros2.git
- release repository: https://github.com/ros2-gbp/sicks300_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## sicks300_ros2

```
* Add a unit test suite for the parser, scanner and scan filter.
* Move serial acquisition to a dedicated thread behind an injectable ``ISerialIO`` transport interface.
* Give the serial read a real wall-clock timeout and make the communication timeout report an error.
* Consolidate diagnostics behind ``diagnostic_updater``.
* Guard against degenerate scans and keep ``angle_min``/``angle_max``, ``angle_increment`` and ``scan_time`` consistent.
* Fix the receive buffer compaction in ``getScan``.
* Replace unaligned ``reinterpret_cast`` reads in the parser with ``memcpy``.
* Remove static state shared between scanner instances.
* Remove the inert scan timestamp synchronization, dead members, stubs and commented-out code.
* Extract ``declare_parameter_if_not_declared`` to a shared header.
* Rename Hungarian-notation identifiers to ``snake_case`` and name magic numbers.
* Pass vectors and strings by const reference.
* Deprecate the ``scan_filter`` node in favor of the ``laser_filters`` package and remove the old laser filter.
* Declare ``lower_angle_``/``upper_angle_`` as ``double`` in ``scan_filter``.
* Rename package to ``sicks300_ros2`` and update publisher QoS.
* Update the CI workflow.
```
