### PR TITLE
kangaroo_robot: 2.15.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4824,7 +4824,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kangaroo_robot-release.git
-      version: 2.15.0-1
+      version: 2.15.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/kangaroo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kangaroo_robot` to `2.15.1-1`:

- upstream repository: https://github.com/pal-robotics/kangaroo_robot.git
- release repository: https://github.com/ros2-gbp/kangaroo_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.0-1`

## kangaroo_bringup

- No changes

## kangaroo_controller_configuration

```
* Add missing broadcaster dependencies
  See merge request robots/kangaroo_robot!177
* Add missing broadcaster dependencies
* Contributors: Sai Kishor Kothakota
```

## kangaroo_description

- No changes

## kangaroo_robot

- No changes
