### PR TITLE
pmb2_robot: 5.12.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8453,7 +8453,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pmb2_robot-release.git
-      version: 5.12.1-1
+      version: 5.12.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.12.2-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/ros2-gbp/pmb2_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.12.1-1`

## pmb2_bringup

```
* Add missing underscore for use_preset
* Fix naming of preset for the pmb2
* Contributors: Noel Jimenez, thomas.peyrucain
```

## pmb2_controller_configuration

- No changes

## pmb2_description

- No changes

## pmb2_robot

- No changes
