### PR TITLE
tiago_dual_simulation: 4.14.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12939,7 +12939,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_dual_simulation-release.git
-      version: 4.13.0-1
+      version: 4.14.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_dual_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_dual_simulation` to `4.14.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_dual_simulation.git
- release repository: https://github.com/ros2-gbp/tiago_dual_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.13.0-1`

## tiago_dual_gazebo

```
* added pal_configuration_manager
* Contributors: antoniobrandi
```

## tiago_dual_simulation

- No changes
