### PR TITLE
tiago_pro_simulation: 1.19.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13086,7 +13086,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_simulation-release.git
-      version: 1.18.0-1
+      version: 1.19.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_simulation` to `1.19.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_simulation.git
- release repository: https://github.com/ros2-gbp/tiago_pro_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.18.0-1`

## tiago_pro_gazebo

```
* added pal_configuration_manager
* Contributors: antoniobrandi
```

## tiago_pro_mujoco

- No changes

## tiago_pro_simulation

- No changes
