### PR TITLE
mujoco_ros2_control: 0.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -6622,7 +6622,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros-controls/mujoco_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_ros2_control` to `0.1.2-1`:

- upstream repository: https://github.com/ros-controls/mujoco_ros2_control.git
- release repository: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.1-1`

## mujoco_3d_lidar

- No changes

## mujoco_ros2_control

```
* Add world_reset plugin hook and restore eq_active on world reset (#294 <https://github.com/ros-controls/mujoco_ros2_control/issues/294>)
* Re-add conditional tinyxml2_vendor dependency (#293 <https://github.com/ros-controls/mujoco_ros2_control/issues/293>)
* Remove deprecated tinyxml2_vendor dependency (#286 <https://github.com/ros-controls/mujoco_ros2_control/issues/286>)
* Shut down ROS when the MuJoCo UI closes (#285 <https://github.com/ros-controls/mujoco_ros2_control/issues/285>)
* Contributors: Bilal Gill, Dylan Gallagher, Erik Holum, Sai Kishor Kothakota
```

## mujoco_ros2_control_demos

- No changes

## mujoco_ros2_control_msgs

- No changes

## mujoco_ros2_control_plugins

```
* Add world_reset plugin hook and restore eq_active on world reset (#294 <https://github.com/ros-controls/mujoco_ros2_control/issues/294>)
* Fix plugin parameter namespaces (#291 <https://github.com/ros-controls/mujoco_ros2_control/issues/291>)
* Contributors: Bilal Gill, Sebastian Castro, Erik Holum
```
