### PR TITLE
message_filters: 4.3.20-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5895,7 +5895,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 4.3.19-1
+      version: 4.3.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `4.3.20-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.3.19-1`

## message_filters

```
* (#163 <https://github.com/ros2/message_filters/issues/163>) Extend registerCallback section in documentation (#326 <https://github.com/ros2/message_filters/issues/326>) (#333 <https://github.com/ros2/message_filters/issues/333>)
* Contributors: mergify[bot]
```
