### PR TITLE
launch: 1.0.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5180,7 +5180,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.0.14-1
+      version: 1.0.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.0.15-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.14-1`

## launch

```
* Correct typos (backport #961 <https://github.com/ros2/launch/issues/961>) (#964 <https://github.com/ros2/launch/issues/964>)
* Contributors: mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

```
* Correct typos (backport #961 <https://github.com/ros2/launch/issues/961>) (#964 <https://github.com/ros2/launch/issues/964>)
* Contributors: mergify[bot]
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
