### PR TITLE
rclcpp: 16.0.21-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9418,7 +9418,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.20-1
+      version: 16.0.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.21-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `16.0.20-1`

## rclcpp

```
* register shutdown callback without shutdown mutex (#3239 <https://github.com/ros2/rclcpp/issues/3239>) (#3241 <https://github.com/ros2/rclcpp/issues/3241>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
