### PR TITLE
ros2_socketcan: 1.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10194,7 +10194,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_socketcan` to `1.4.0-1`:

- upstream repository: https://github.com/autowarefoundation/ros2_socketcan.git
- release repository: https://github.com/ros2-gbp/ros2_socketcan-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.0-1`

## ros2_socketcan

```
* Added ``warn_on_receive_timeout`` to control timeout warnings without suppressing other receive errors (#101 <https://github.com/autowarefoundation/ros2_socketcan/issues/101>).
* Stopped and joined the receiver thread on node destruction, lifecycle cleanup, and shutdown (#100 <https://github.com/autowarefoundation/ros2_socketcan/issues/100>).
* Added ``rx:<interface>`` receiver thread names and five tests for destruction and reconfiguration (#99 <https://github.com/autowarefoundation/ros2_socketcan/issues/99>).
* Added optional Agnocast support with ``CallbackIsolatedAgnocastExecutor`` (#98 <https://github.com/autowarefoundation/ros2_socketcan/issues/98>).
* Added the sender-only ``enable_frame_loopback`` parameter, disabled by default (#97 <https://github.com/autowarefoundation/ros2_socketcan/issues/97>).
* Added an ``enable_loopback`` argument before ``default_id`` in the ``SocketCanSender`` constructor (#97 <https://github.com/autowarefoundation/ros2_socketcan/issues/97>).
* Added the ``filters`` argument to the XML bridge launch file (#96 <https://github.com/autowarefoundation/ros2_socketcan/issues/96>).
* Enabled CAN FD topic remapping through the launch files (#94 <https://github.com/autowarefoundation/ros2_socketcan/issues/94>).
* Added support for variable-length CAN FD frames (#93 <https://github.com/autowarefoundation/ros2_socketcan/issues/93>).
* Fixed rejection of extended CAN IDs with the extended-frame flag set (#92 <https://github.com/autowarefoundation/ros2_socketcan/issues/92>).
* Renamed the design document to ``README.md`` (#91 <https://github.com/autowarefoundation/ros2_socketcan/issues/91>).
* Installed headers under a package-specific include directory with ``USE_SCOPED_HEADER_INSTALL_DIR`` (#68 <https://github.com/autowarefoundation/ros2_socketcan/issues/68>).
* Contributors: Finn S., Mete Fatih Cırıt
```

## ros2_socketcan_msgs

```
* Updated the version to match ``ros2_socketcan``. Message definitions are unchanged.
```
