### PR TITLE
ros2_socketcan: 1.4.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   debian:
@@ -8523,7 +8523,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
-      version: 1.3.0-3
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_socketcan` to `1.4.0-1`:

- upstream repository: https://github.com/autowarefoundation/ros2_socketcan.git
- release repository: https://github.com/ros2-gbp/ros2_socketcan-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.0-3`

## ros2_socketcan

```
* Added ``warn_on_receive_timeout`` to control timeout warnings without suppressing other receive errors (#59 <https://github.com/autowarefoundation/ros2_socketcan/issues/59>).
* Stopped and joined the receiver thread on node destruction, lifecycle cleanup, and shutdown (#75 <https://github.com/autowarefoundation/ros2_socketcan/issues/75>).
* Added ``rx:<interface>`` receiver thread names and five tests for destruction and reconfiguration (#89 <https://github.com/autowarefoundation/ros2_socketcan/issues/89>).
* Added optional Agnocast support with ``CallbackIsolatedAgnocastExecutor`` (#72 <https://github.com/autowarefoundation/ros2_socketcan/issues/72>).
* Added the sender-only ``enable_frame_loopback`` parameter, disabled by default (#66 <https://github.com/autowarefoundation/ros2_socketcan/issues/66>).
* Added an ``enable_loopback`` argument before ``default_id`` in the ``SocketCanSender`` constructor (#66 <https://github.com/autowarefoundation/ros2_socketcan/issues/66>).
* Added the ``filters`` argument to the XML bridge launch file (#63 <https://github.com/autowarefoundation/ros2_socketcan/issues/63>).
* Enabled CAN FD topic remapping through the launch files (#52 <https://github.com/autowarefoundation/ros2_socketcan/issues/52>).
* Added support for variable-length CAN FD frames (#50 <https://github.com/autowarefoundation/ros2_socketcan/issues/50>).
* Fixed rejection of extended CAN IDs with the extended-frame flag set (#40 <https://github.com/autowarefoundation/ros2_socketcan/issues/40>).
* Renamed the design document to ``README.md`` (#37 <https://github.com/autowarefoundation/ros2_socketcan/issues/37>).
* Contributors: Albers Franz, ChinYikMing, Ismet Atabay, Joshua Whitley, Kevin Hallenbeck, M. Fatih Cırıt, Mete Fatih Cırıt, Ryohsuke Mitsudome, Tetsuhiro Kawaguchi, Tony Baltovski
```

## ros2_socketcan_msgs

```
* Updated the version to match ``ros2_socketcan``. Message definitions are unchanged.
```
