### PR TITLE
rosbag2: 0.15.17-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10897,7 +10897,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.16-1
+      version: 0.15.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.17-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.15.16-1`

## mcap_vendor

- No changes

## ros2bag

```
* Added option to change node name for the recorder from the Python API (#1180 <https://github.com/ros2/rosbag2/issues/1180>) (#2437 <https://github.com/ros2/rosbag2/issues/2437>)
* Contributors: Fabian Hirmann
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* docs: fix Reader usage examples (#2455 <https://github.com/ros2/rosbag2/issues/2455>) (#2459 <https://github.com/ros2/rosbag2/issues/2459>)
* Added writer for std::shared_ptr<const rclcpp::SerializedMessage> (#2356 <https://github.com/ros2/rosbag2/issues/2356>)
* Contributors: Jacob Cohen, mergify[bot]
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* Added option to change node name for the recorder from the Python API (#1180 <https://github.com/ros2/rosbag2/issues/1180>) (#2437 <https://github.com/ros2/rosbag2/issues/2437>)
* Contributors: Fabian Hirmann
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [humble] Add missing "RecordOptions" fields to the encode/decode functions (backport #2334 <https://github.com/ros2/rosbag2/issues/2334>) (#2339 <https://github.com/ros2/rosbag2/issues/2339>)
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
