### PR TITLE
urdf_test: 2.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -13510,7 +13510,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/urdf_test-release.git
-      version: 2.1.1-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/urdf_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `2.1.3-1`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/ros2-gbp/urdf_test-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.1-1`

## urdf_test

```
* Use urdfdom as a exec dependency
* Contributors: Sai Kishor Kothakota
```
