### PR TITLE
urdf_test: 2.1.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11448,7 +11448,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/urdf_test-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/urdf_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `2.1.3-1`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/ros2-gbp/urdf_test-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.2-1`

## urdf_test

```
* Use urdfdom as a exec dependency
* Contributors: Sai Kishor Kothakota
```
