### PR TITLE
control_msgs: 5.10.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -1905,7 +1905,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.9.0-1
+      version: 5.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.10.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.9.0-1`

## control_msgs

```
* Add JointCommand.msg as semantic alternative to Float64MultiArray (#304 <https://github.com/ros-controls/control_msgs/issues/304>) (#329 <https://github.com/ros-controls/control_msgs/issues/329>)
* Contributors: mergify[bot]
```
