### PR TITLE
rewire_ros: 0.1.1-1 in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9602,6 +9602,23 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: humble
     status: maintained
+  rewire_ros:
+    doc:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    release:
+      packages:
+      - rewire
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/rewire-run/rewire-ros-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    status: developed
   rig_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

Source repository: https://github.com/rewire-run/rewire-ros
Release repository: https://github.com/rewire-run/rewire-ros-release, generated with bloom. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro