### PR TITLE
rewire_ros: 0.1.1-1 in jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9207,6 +9207,23 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: jazzy
     status: maintained
+  rewire_ros:
+    doc:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    release:
+      packages:
+      - rewire
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/rewire-run/rewire-ros-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    status: developed
   rig_reconfigure:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

Source repository: https://github.com/rewire-run/rewire-ros
Release repository: https://github.com/rewire-run/rewire-ros-release, generated with bloom. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro