### PR TITLE
rewire_ros: 0.1.1-1 in lyrical

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7604,6 +7604,23 @@ repositories:
       url: https://github.com/ros2/resource_retriever_service.git
       version: lyrical
     status: maintained
+  rewire_ros:
+    doc:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    release:
+      packages:
+      - rewire
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/rewire-run/rewire-ros-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    status: developed
   rig_reconfigure:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

lyrical

# The source is here:

Source repository: https://github.com/rewire-run/rewire-ros
Release repository: https://github.com/rewire-run/rewire-ros-release, generated with bloom. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro