### PR TITLE
rewire_ros: 0.1.1-1 in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7210,6 +7210,16 @@ repositories:
       url: https://github.com/ros2/resource_retriever_service.git
       version: rolling
     status: maintained
+  rewire_ros:
+    doc:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/rewire-run/rewire-ros.git
+      version: main
+    status: developed
   rig_reconfigure:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

Source repository: https://github.com/rewire-run/rewire-ros
Release repository: https://github.com/rewire-run/rewire-ros-release, generated with bloom. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro