### PR TITLE
fusioncore: 0.3.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -3503,7 +3503,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.8-1
+      version: 0.3.9-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fusioncore` to `0.3.9-1`:

- upstream repository: https://github.com/manankharwar/fusioncore
- release repository: https://github.com/manankharwar/fusioncore-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.8-1`
