### PR TITLE
fields2cover: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -3167,7 +3167,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fields2cover-release.git
-      version: 2.0.0-10
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `2.1.0-1`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/ros2-gbp/fields2cover-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-10`
