### PR TITLE
data_tamer_tools: 0.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -1600,7 +1600,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer_tools-release.git
-      version: 0.4.0-2
+      version: 0.11.0-1
     source:
       type: git
       url: https://gitlab.com/jlack/data_tamer_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer_tools` to `0.11.0-1`:

- upstream repository: https://gitlab.com/jlack/data_tamer_tools.git
- release repository: https://github.com/ros2-gbp/data_tamer_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-2`
