### PR TITLE
linear_feedback_controller_msgs: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -5518,7 +5518,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
-      version: 1.2.2-2
+      version: 1.3.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_feedback_controller_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/loco-3d/linear-feedback-controller-msgs.git
- release repository: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.2-2`
