### PR TITLE
linear_feedback_controller_msgs: 1.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4258,7 +4258,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
-      version: 1.2.2-2
+      version: 1.3.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_feedback_controller_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/loco-3d/linear-feedback-controller-msgs.git
- release repository: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.2-2`
