### PR TITLE
imu_tools: 2.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3471,7 +3471,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.2.4-2
+      version: 2.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.2.5-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.4-2`

## imu_complementary_filter

```
* Use SPDX license tags in package.xml (#235 <https://github.com/CCNYRoboticsLab/imu_tools/issues/235>)
* Fix quaternion interpolation threshold (#234 <https://github.com/CCNYRoboticsLab/imu_tools/issues/234>)
* CI: fix pre-commit failures on Python 3.14 / clang-format 21 (#237 <https://github.com/CCNYRoboticsLab/imu_tools/issues/237>)
* Contributors: Daniiiil1, Martin Günther, Michal Sojka
```

## imu_filter_madgwick

```
* Use SPDX license tags in package.xml (#235 <https://github.com/CCNYRoboticsLab/imu_tools/issues/235>)
* CI: fix pre-commit failures on Python 3.14 / clang-format 21 (#237 <https://github.com/CCNYRoboticsLab/imu_tools/issues/237>)
* Contributors: Martin Günther, Michal Sojka
```

## imu_tools

```
* Use SPDX license tags in package.xml (#235 <https://github.com/CCNYRoboticsLab/imu_tools/issues/235>)
* Contributors: Michal Sojka
```

## rviz_imu_plugin

```
* Add missing includes (#236 <https://github.com/CCNYRoboticsLab/imu_tools/issues/236>)
* Use SPDX license tags in package.xml (#235 <https://github.com/CCNYRoboticsLab/imu_tools/issues/235>)
* CI: fix pre-commit failures on Python 3.14 / clang-format 21 (#237 <https://github.com/CCNYRoboticsLab/imu_tools/issues/237>)
* Contributors: Martin Günther, Michal Sojka
```
