### PR TITLE
boost_plugin_loader: 0.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   debian:
@@ -1040,7 +1040,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/boost_plugin_loader-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/tesseract-robotics/boost_plugin_loader.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_plugin_loader` to `0.4.5-1`:

- upstream repository: https://github.com/tesseract-robotics/boost_plugin_loader.git
- release repository: https://github.com/ros2-gbp/boost_plugin_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.4-1`

## boost_plugin_loader

```
* Add plugin library lifetime tokens
  Add an explicit API for eagerly loading configured plugin libraries and
  returning independent RAII lifetime tokens.
  Each token includes the resolved library path for deduplication and retains
  type-erased shared ownership after the originating PluginLoader is cleared
  or destroyed.
  Add unit coverage for token acquisition and ownership persistence.
* Cancel superseded pull-request CI runs
  Five workflows trigger on push, pull_request and a daily cron with no
  concurrency group, so every push to an open PR left the previous run
  building. Supersede in-progress pull-request runs only; pushes and cron
  runs still queue so two runs on one ref never race.
  Co-Authored-By: Claude Opus 5 <mailto:noreply@anthropic.com>
* Bump colcon-action to v15 on Windows
  v15 is the first release with Windows ccache support, so this is the
  only platform gaining caching it never had. The -G "Ninja" already
  passed in both arg sets is the precondition: the Visual Studio generator
  ignores CMAKE_<LANG>_COMPILER_LAUNCHER silently, and the only symptom
  would be zero cacheable calls.
  The prefix named matrix.distro, a key this single-leg job never defined,
  so it expanded to the empty string.
  Co-Authored-By: Claude Opus 5 <mailto:noreply@anthropic.com>
* Bump colcon-action to v15 on Linux and macOS
  ccache has never worked on either platform. The save step never ran, so
  every run was cold, and the launcher never reached the compiler: on Linux
  it was passed in a second --cmake-args group, which colcon drops as
  last-wins; on macOS if [ ... = "true" ]] errors and forced the
  no-launcher branch. That same bracket also skipped rosdep install, so
  fixing it would newly run rosdep against a package.xml declaring
  libboost-filesystem-dev, which has no Homebrew mapping and nothing to
  install there - Boost comes from vcpkg. Disable it on macOS instead.
  CCACHE_DIR was load-bearing under v14, whose cache path was relative;
  v15 resolves the directory itself, so drop it.
  Co-Authored-By: Claude Opus 5 <mailto:noreply@anthropic.com>
* Contributors: Levi Armstrong, Roelof Oomen
```
