### PR TITLE
clearpath_config: 2.9.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1526,7 +1526,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.9.6-1
+      version: 2.9.7-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.9.7-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.6-1`

## clearpath_config

```
* Feature: Add Support for Hesai Lidar (#250 <https://github.com/clearpathrobotics/clearpath_config/issues/250>)
* Add Realsense d405 as option (#251 <https://github.com/clearpathrobotics/clearpath_config/issues/251>)
* Added notes about the CI. (#253 <https://github.com/clearpathrobotics/clearpath_config/issues/253>)
* Fix: Merge Dict (#246 <https://github.com/clearpathrobotics/clearpath_config/issues/246>)
  Recursively apply priority in dictionary merge
* Bump https://github.com/igorshubovych/markdownlint-cli from v0.44.0 to 0.49.1 (#248 <https://github.com/clearpathrobotics/clearpath_config/issues/248>)
* Bump https://github.com/PyCQA/flake8 from 7.1.2 to 7.3.0 (#247 <https://github.com/clearpathrobotics/clearpath_config/issues/247>)
* Bump https://github.com/pre-commit/pre-commit-hooks from v5.0.0 to 6.0.0 (#249 <https://github.com/clearpathrobotics/clearpath_config/issues/249>)
* Added PR template, updated issue template and README. (#245 <https://github.com/clearpathrobotics/clearpath_config/issues/245>)
* Contributors: Tony Baltovski, dependabot[bot], luis-camero, mibrahim-cpr
```
