### PR TITLE
clearpath_config: 1.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   rhel:
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 1.3.3-1
+      version: 1.3.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `1.3.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.3-1`

## clearpath_config

```
* Fix: Merge Dict (#246 <https://github.com/clearpathrobotics/clearpath_config/issues/246>) (#252 <https://github.com/clearpathrobotics/clearpath_config/issues/252>)
* [Humble] Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image. (#217 <https://github.com/clearpathrobotics/clearpath_config/issues/217>)
* Contributors: mergify[bot]
```
