### PR TITLE
clearpath_common: 1.3.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   rhel:
@@ -1703,7 +1703,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.3.12-1
+      version: 1.3.13-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.3.13-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.12-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Fix: Merge Dict (#377 <https://github.com/clearpathrobotics/clearpath_common/issues/377>) (#384 <https://github.com/clearpathrobotics/clearpath_common/issues/384>)
  Invert priority of UR update rate
  (cherry picked from commit b0f6d920422ad302372a1c65e31d61648da884ed)
  Co-authored-by: luis-camero <mailto:88782189+luis-camero@users.noreply.github.com>
* Contributors: mergify[bot]
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

```
* Add Hokuyo collision (#381 <https://github.com/clearpathrobotics/clearpath_common/issues/381>) (#383 <https://github.com/clearpathrobotics/clearpath_common/issues/383>)
  (cherry picked from commit eda69e1a52fedf23c1ac5f25dd5bffd5a2272881)
  Co-authored-by: luis-camero <mailto:88782189+luis-camero@users.noreply.github.com>
* Contributors: mergify[bot]
```
