### PR TITLE
ros2launch_security: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 143: https://reps.openrobotics.org/rep-0143/
 ---
 release_platforms:
   rhel:
@@ -10687,7 +10687,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
-      version: 1.0.0-3
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2launch_security` to `1.0.2-1`:

- upstream repository: https://github.com/osrf/ros2launch_security.git
- release repository: https://github.com/ros2-gbp/ros2launch_security-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-3`

## ros2launch_security

```
* Update dependency from nodl_python to nodl (#14 <https://github.com/osrf/ros2launch_security/issues/14>)
* Contributors: William Woodall
```

## ros2launch_security_examples

```
* Update dependency from nodl_python to nodl (#14 <https://github.com/osrf/ros2launch_security/issues/14>)
* Contributors: William Woodall
```
