### PR TITLE
ament_cmake_ros: 0.12.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -322,11 +322,12 @@ repositories:
     release:
       packages:
       - ament_cmake_ros
+      - ament_cmake_ros_core
       - domain_coordinator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.12.1-1
+      version: 0.12.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.12.2-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.12.1-1`

## ament_cmake_ros

- No changes

## ament_cmake_ros_core

```
* Split generic parts of ament_cmake_ros into _core package + Add ament_ros_defaults target (manual Jazzy backport of #20 <https://github.com/ros2/ament_cmake_ros/issues/20> and #62 <https://github.com/ros2/ament_cmake_ros/issues/62>) (#67 <https://github.com/ros2/ament_cmake_ros/issues/67>)
* Contributors: Martin Pecka
```

## domain_coordinator

- No changes
