### PR TITLE
message_filters: 8.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4434,7 +4434,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 8.0.3-1
+      version: 8.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `8.0.4-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `8.0.3-1`

## message_filters

```
* Fixed doxygen warnings (#329 <https://github.com/ros2/message_filters/issues/329>)
* Include what you use (#334 <https://github.com/ros2/message_filters/issues/334>)
* (#163 <https://github.com/ros2/message_filters/issues/163>) Extend registerCallback section in documentation (#326 <https://github.com/ros2/message_filters/issues/326>)
* Granular rclcpp/rclcpp.hpp also in documentation (#328 <https://github.com/ros2/message_filters/issues/328>)
* Contributors: Alejandro Hernández Cordero, Pavel Esipov
```
