### PR TITLE
py_trees: 2.6.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6846,7 +6846,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.6.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/ros2-gbp/py_trees-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.0-1`

## py_trees

```
* [ports] Do not raise error if a port value starts with a / (#514 <https://github.com/splintered-reality/py_trees/issues/514>)
* [ports] Handle blackboard keys in parsing XML for built-in behaviors (#513 <https://github.com/splintered-reality/py_trees/issues/513>)
* [ports] Change input/output port declarations to class attributes (#511 <https://github.com/splintered-reality/py_trees/issues/511>)
* [ports] Add default values to PortInformation (#510 <https://github.com/splintered-reality/py_trees/issues/510>)
* [ports] Top-level input port default values in behavior tree XML (#509 <https://github.com/splintered-reality/py_trees/issues/509>)
* [ports] Support ports that are types and treat string ports conversion properly. (#507 <https://github.com/splintered-reality/py_trees/issues/507>)
* [composites] Recover memory sequences after child replacement (#505 <https://github.com/splintered-reality/py_trees/issues/505>)
* [infra] Use older license syntax to make ROS happy
* [infra] Fix build warnings (#506 <https://github.com/splintered-reality/py_trees/issues/506>)
* [docs] Add installation and getting started instructions (#504 <https://github.com/splintered-reality/py_trees/issues/504>)
* Contributors: Filip Grčar, Jennifer Buehler, Sanjay Santhanam, Sebastian Castro
```
