### PR TITLE
rosdep: add openeuler package mappings for common keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -676,6 +676,7 @@ cmake:
   macports: [cmake]
   nixos: [cmake]
   openembedded: [cmake@openembedded-core]
+  openeuler: [cmake]
   opensuse: [cmake]
   rhel: [cmake3]
   slackware:
@@ -761,6 +762,7 @@ coreutils:
   gentoo: [sys-apps/coreutils]
   nixos: [coreutils]
   openembedded: [coreutils@openembedded-core]
+  openeuler: [coreutils]
   ubuntu: [coreutils]
 couchdb:
   arch: [couchdb]
@@ -783,6 +785,7 @@ cppcheck:
   gentoo: [dev-util/cppcheck]
   nixos: [cppcheck]
   openembedded: [cppcheck@meta-ros-common]
+  openeuler: [cppcheck]
   osx:
     homebrew:
       packages: [cppcheck]
@@ -798,6 +801,7 @@ cppunit:
   macports: [cppunit]
   nixos: [cppunit]
   openembedded: [cppunit@meta-oe]
+  openeuler: [cppunit-devel]
   opensuse: [cppunit-devel]
   rhel: [cppunit-devel]
   slackware: [cppunit]
@@ -921,6 +925,7 @@ dkms:
   gentoo: [sys-kernel/dkms]
   nixos: []
   openembedded: []
+  openeuler: [dkms]
   opensuse: [dkms]
   rhel: [dkms]
   ubuntu: [dkms]
@@ -931,6 +936,7 @@ dnsmasq:
   gentoo: [net-dns/dnsmasq]
   nixos: [dnsmasq]
   openembedded: [dnsmasq@meta-networking]
+  openeuler: [dnsmasq]
   ubuntu: [dnsmasq]
 docker-compose:
   arch: [docker-compose]
@@ -938,6 +944,7 @@ docker-compose:
   fedora: [docker-compose]
   nixos: [docker-compose]
   openembedded: [docker-compose@meta-virtualization]
+  openeuler: [docker-compose]
   ubuntu: [docker-compose]
 docker.io:
   debian:
@@ -966,6 +973,7 @@ dpkg:
   gentoo: [app-arch/dpkg]
   nixos: [dpkg]
   openembedded: [dpkg@openembedded-core]
+  openeuler: [dpkg]
   rhel: [dpkg]
   ubuntu: [dpkg]
 dpkg-dev:
@@ -973,6 +981,7 @@ dpkg-dev:
   fedora: [dpkg-dev]
   nixos: [dpkg]
   openembedded: [dpkg@openembedded-core]
+  openeuler: [dpkg-dev]
   ubuntu: [dpkg-dev]
 dvipng:
   arch: [texlive-bin]
@@ -1937,6 +1946,7 @@ gtest:
   macports: [ros-gtest]
   nixos: [gtest]
   openembedded: [gtest@meta-oe]
+  openeuler: [gtest]
   opensuse: [gtest]
   rhel: [gtest-devel]
   slackware: [gtest]
@@ -1947,6 +1957,7 @@ gtk-doc-tools:
   fedora: [gtk-doc]
   gentoo: [dev-util/gtk-doc]
   nixos: [gtk-doc]
+  openeuler: [gtk-doc]
   ubuntu: [gtk-doc-tools]
 gtk2:
   arch: [gtk2]
@@ -1957,6 +1968,7 @@ gtk2:
   macports: [gtk2]
   nixos: [gtk2]
   openembedded: [gtk+@openembedded-core]
+  openeuler: [gtk2-devel]
   opensuse: [gtk2-devel]
   rhel: [gtk2-devel]
   slackware:
@@ -2656,6 +2668,7 @@ jython:
   debian: [jython]
   gentoo: [dev-java/jython]
   nixos: [jython]
+  openeuler: [jython]
   ubuntu: [jython]
 kakasi:
   arch: [kakasi]
@@ -3559,6 +3572,7 @@ libclang-dev:
   gentoo: [sys-devel/clang]
   nixos: [clang]
   openembedded: [clang@openembedded-core]
+  openeuler: [clang-devel]
   rhel: [clang-devel]
   ubuntu: [libclang-dev]
 libcoin60-dev:
@@ -3595,6 +3609,7 @@ libconfig++-dev:
   fedora: [libconfig-devel]
   gentoo: ['dev-libs/libconfig[cxx]']
   nixos: [libconfig]
+  openeuler: [libconfig-devel]
   rhel: [libconfig-devel]
   ubuntu: [libconfig++-dev]
 libconfig-dev:
@@ -8177,6 +8192,7 @@ libzstd-dev:
   gentoo: [app-arch/zstd]
   nixos: [zstd]
   openembedded: [zstd@openembedded-core]
+  openeuler: [zstd-dev]
   rhel: [libzstd-devel]
   ubuntu:
     '*': [libzstd-dev]
@@ -9300,6 +9316,7 @@ python-dev:
   debian: [python-dev]
   fedora: [python2-devel]
   nixos: [pythonPackages.python]
+  openeuler: [python3-devel]
   rhel:
     '7': [python2-devel]
     '8': [python2-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -354,6 +354,7 @@ meson:
   fedora: [meson]
   gentoo: [dev-build/meson]
   nixos: [meson]
+  openeuler: [meson]
   opensuse: [meson]
   rhel: [meson]
   ubuntu: [meson]
@@ -3955,6 +3956,7 @@ python3-evdev:
     stretch: null
   fedora: [python3-evdev]
   gentoo: [dev-python/python-evdev]
+  openeuler: [python3-evdev]
   osx:
     pip:
       packages: [evdev]
@@ -4152,6 +4154,7 @@ python3-flake8:
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
   openembedded: [python3-flake8@meta-ros-common]
+  openeuler: [python3-flake8]
   opensuse: [python3-flake8]
   osx:
     pip:
@@ -4386,6 +4389,7 @@ python3-flask:
   gentoo: [dev-python/flask]
   nixos: [python3Packages.flask]
   openembedded: [python3-flask@meta-python]
+  openeuler: [python3-flask]
   rhel: [python3-flask]
   ubuntu: [python3-flask]
 python3-flask-bcrypt:
@@ -4947,6 +4951,7 @@ python3-importlib-metadata:
   gentoo: [dev-python/importlib-metadata]
   nixos: [python3Packages.importlib-metadata]
   openembedded: [python3-importlib-metadata@meta-python]
+  openeuler: [python3-importlib_metadata]
   osx:
     pip:
       packages: [importlib_metadata]
@@ -4974,6 +4979,7 @@ python3-importlib-resources:
   gentoo: [dev-lang/python]
   nixos: [python3Packages.importlib-resources]
   openembedded: [python3@openembedded-core]
+  openeuler: [python3-importlib-resources]
   osx:
     pip:
       packages: [importlib-resources]
@@ -5108,6 +5114,7 @@ python3-joblib:
   fedora: [python-joblib]
   gentoo: [dev-python/joblib]
   nixos: [python3Packages.joblib]
+  openeuler: [python3-joblib]
   opensuse: [python3-joblib]
   ubuntu: [python3-joblib]
 python3-jraph-pip:
@@ -5336,6 +5343,7 @@ python3-lockfile:
   fedora: [python3-lockfile]
   gentoo: [dev-python/lockfile]
   nixos: [python3Packages.lockfile]
+  openeuler: [python3-lockfile]
   opensuse: [python-lockfile]
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]
@@ -5363,6 +5371,7 @@ python3-lxml:
   gentoo: [dev-python/lxml]
   nixos: [python3Packages.lxml]
   openembedded: [python3-lxml@openembedded-core]
+  openeuler: [python3-lxml]
   opensuse: [python3-lxml]
   osx:
     pip:
@@ -5417,12 +5426,14 @@ python3-markdown:
   fedora: [python3-markdown]
   gentoo: [dev-python/markdown]
   nixos: [python3Packages.markdown]
+  openeuler: [python3-markdown]
   ubuntu: [python3-markdown]
 python3-marshmallow:
   debian: [python3-marshmallow]
   fedora: [python3-marshmallow]
   gentoo: [dev-python/marshmallow]
   nixos: [python3Packages.marshmallow]
+  openeuler: [python3-marshmallow]
   opensuse: [python3-marshmallow]
   rhel:
     '*': ['python%{python3_pkgversion}-marshmallow']
@@ -7452,6 +7463,7 @@ python3-pytest:
   gentoo: [dev-python/pytest]
   nixos: [python3Packages.pytest]
   openembedded: [python3-pytest@openembedded-core]
+  openeuler: [python3-pytest]
   opensuse: [python3-pytest]
   osx:
     pip:
@@ -7492,6 +7504,7 @@ python3-pytest-cov:
   gentoo: [dev-python/pytest-cov]
   nixos: [python3Packages.pytestcov]
   openembedded: [python3-pytest-cov@meta-ros-common]
+  openeuler: [python3-pytest-cov]
   rhel: ['python%{python3_pkgversion}-pytest-cov']
   ubuntu: [python3-pytest-cov]
 python3-pytest-dependency:
@@ -7517,6 +7530,7 @@ python3-pytest-mock:
   gentoo: [dev-python/pytest-mock]
   nixos: [python3Packages.pytest-mock]
   openembedded: [python3-pytest-mock@meta-ros-common]
+  openeuler: [python3-pytest-mock]
   opensuse: [python3-pytest-mock]
   osx:
     pip:
@@ -7561,6 +7575,7 @@ python3-pytest-timeout:
   gentoo: [dev-python/pytest-timeout]
   nixos: [python3Packages.pytest-timeout]
   openembedded: [python3-pytest-timeout@meta-python]
+  openeuler: [python3-pytest-timeout]
   opensuse: [python3-pytest-timeout]
   rhel: ['python%{python3_pkgversion}-pytest-timeout']
   ubuntu: [python3-pytest-timeout]
@@ -8320,6 +8335,7 @@ python3-setuptools:
   gentoo: [dev-python/setuptools]
   nixos: [python3Packages.setuptools]
   openembedded: [python3-setuptools@openembedded-core]
+  openeuler: [python3-setuptools]
   opensuse: [python3-setuptools]
   osx:
     pip:


### PR DESCRIPTION
This PR re-applies the changes from #36933, which was closed in 2023 pending upstream openeuler support in rosdep. All prerequisite work has since landed:

- ros-infrastructure/rospkg#260 was superseded by ros-infrastructure/rospkg#274 (openeuler OS detection)
- ros-infrastructure/rosdep#919 was resolved by ros-infrastructure/rosdep#1021 (openeuler platform support, DNF/YUM/PIP installers)

The fork that hosted the original PR has since been deleted, so it cannot be reopened; this PR recreates it against current master.

Changes:

- adds `openeuler` mappings to 17 keys in `rosdep/base.yaml` and 16 keys in `rosdep/python.yaml`
- entries are placed in alphabetical order within each key block, as enforced by `scripts/check_rosdep.py`
- the original patch's `python-evdev`, `python-flake8` and `python-flask` keys no longer exist in `python.yaml`; their `python3-*` equivalents (`python3-evdev`, `python3-flask`) are used instead

Verified locally with `test/rosdep_formatting_test.py` and `test/rosdep_duplicates_test.py`.

Original patch by @Z572.