### PR TITLE
bond_core: 4.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1009,7 +1009,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.4.0-2
+      version: 4.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.4.1-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.4.0-2`

## bond

```
* Reuse bond heartbeat watchdog timer (#116 <https://github.com/ros/bond_core//issues/116>)
* Contributors: Maurice Alexander Purnawan
```

## bond_core

```
* Reuse bond heartbeat watchdog timer (#116 <https://github.com/ros/bond_core//issues/116>)
* Contributors: Maurice Alexander Purnawan
```

## bondcpp

```
* Reuse bond heartbeat watchdog timer (#116 <https://github.com/ros/bond_core//issues/116>)
* Contributors: Maurice Alexander Purnawan
```

## bondpy

```
* Fix deprecated bondpy setuptools options (#117 <https://github.com/ros/bond_core//issues/117>)
* Contributors: Maurice Alexander Purnawan
```

## smclib

```
* Reuse bond heartbeat watchdog timer (#116 <https://github.com/ros/bond_core//issues/116>)
* Contributors: Maurice Alexander Purnawan
```
