### PR TITLE
rmw_zenoh: 0.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -7728,7 +7728,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.12.0-1
+      version: 0.13.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.13.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.12.0-1`

## rmw_zenoh_cpp

```
* Granular rclcpp/rclcpp.gpp and include what you use (#1043 <https://github.com/ros2/rmw_zenoh/issues/1043>)
* Return topic info by const reference (#1053 <https://github.com/ros2/rmw_zenoh/issues/1053>)
* Remove unnecessary topic info locks (#1048 <https://github.com/ros2/rmw_zenoh/issues/1048>)
* Add rmw_zenoh_cpp to zenoh_cpp_vendor runtime dep (#1044 <https://github.com/ros2/rmw_zenoh/issues/1044>)
* Do not update wait_set_data triggered flag outside of mutex lock (#1036 <https://github.com/ros2/rmw_zenoh/issues/1036>)
* When SHM enabled, enable transport_optimization (#1020 <https://github.com/ros2/rmw_zenoh/issues/1020>)
* return early when unable to find any topic endpoints. (#1017 <https://github.com/ros2/rmw_zenoh/issues/1017>)
* Contributors: Alejandro Hernández Cordero, Julien Enoch, Maurice Alexander Purnawan, Scott K Logan, Tomoya Fujita, Yadunund
```

## zenoh_cpp_vendor

```
* Silence informational zenoh-c build-script warnings (#1047 <https://github.com/ros2/rmw_zenoh/issues/1047>)
* Contributors: Michael Carroll
```

## zenoh_security_tools

```
* Granular rclcpp/rclcpp.gpp and include what you use (#1043 <https://github.com/ros2/rmw_zenoh/issues/1043>)
* Contributors: Alejandro Hernández Cordero
```
