### PR TITLE
rmw_zenoh: 0.10.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -8107,7 +8107,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.10.5-1
+      version: 0.10.6-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.10.6-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.10.5-1`

## rmw_zenoh_cpp

```
* Return topic info by const reference (#1055 <https://github.com/ros2/rmw_zenoh/issues/1055>)
* Remove unnecessary topic info locks (#1049 <https://github.com/ros2/rmw_zenoh/issues/1049>)
* Add rmw_zenoh_cpp to zenoh_cpp_vendor runtime dep (#1045 <https://github.com/ros2/rmw_zenoh/issues/1045>)
* Do not update wait_set_data triggered flag outside of mutex lock (#1038 <https://github.com/ros2/rmw_zenoh/issues/1038>)
* When SHM enabled, enable transport_optimization (#1021 <https://github.com/ros2/rmw_zenoh/issues/1021>)
* return early when unable to find any topic endpoints. (#1019 <https://github.com/ros2/rmw_zenoh/issues/1019>)
* return early with a zero-initialized array. (#1018 <https://github.com/ros2/rmw_zenoh/issues/1018>)
* Contributors: Julien Enoch, Maurice Alexander Purnawan, Scott K Logan, Tomoya Fujita, Yadunund
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

- No changes
