### PR TITLE
rmw_zenoh: 0.6.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: https://reps.openrobotics.org/rep-0143/
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   debian:
@@ -7827,7 +7827,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.7-1
+      version: 0.6.8-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.6.8-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.7-1`

## rmw_zenoh_cpp

```
* Return topic info by const reference (#1056 <https://github.com/ros2/rmw_zenoh/issues/1056>)
* Remove unnecessary topic info locks (#1050 <https://github.com/ros2/rmw_zenoh/issues/1050>)
* Do not update wait_set_data triggered flag outside of mutex lock (#1039 <https://github.com/ros2/rmw_zenoh/issues/1039>)
* return early when unable to find any topic endpoints. (#1027 <https://github.com/ros2/rmw_zenoh/issues/1027>)
* When SHM enabled, enable transport_optimization (#1022 <https://github.com/ros2/rmw_zenoh/issues/1022>)
* Contributors: Alejandro Hernandez Cordero, Julien Enoch, Maurice Alexander Purnawan, Tomoya Fujita, Yadunund
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

- No changes
