### PR TITLE
rmw_zenoh: 0.2.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9684,7 +9684,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.10-1
+      version: 0.2.11-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.2.11-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.10-1`

## rmw_zenoh_cpp

```
* Return topic info by const reference (#1057 <https://github.com/ros2/rmw_zenoh/issues/1057>)
* Remove unnecessary topic info locks (#1051 <https://github.com/ros2/rmw_zenoh/issues/1051>)
* Do not update wait_set_data triggered flag outside of mutex lock (#1040 <https://github.com/ros2/rmw_zenoh/issues/1040>)
* return early when unable to find any topic endpoints. (#1026 <https://github.com/ros2/rmw_zenoh/issues/1026>)
* When SHM enabled, enable transport_optimization (#1023 <https://github.com/ros2/rmw_zenoh/issues/1023>)
* Contributors: Alejandro Hernandez Cordero, Julien Enoch, Maurice Alexander Purnawan, Tomoya Fujita, Yadunund
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

- No changes
