### PR TITLE
Fix python3-ruamel.yaml for NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8107,7 +8107,7 @@ python3-ruamel.yaml:
     buster: [python3-ruamel.yaml]
     stretch: [python3-ruamel.yaml]
   fedora: [python3-ruamel-yaml]
-  nixos: [python3Packages.ruamel_yaml]
+  nixos: [python3Packages.ruamel-yaml]
   openembedded: [python3-ruamel-yaml@openembedded-core]
   rhel: ['python%{python3_pkgversion}-ruamel-yaml']
   ubuntu: [python3-ruamel.yaml]


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/blob/dc5d91f840324650bac8c379428c7037a416959a/pkgs/top-level/python-aliases.nix#L676.
