### PR TITLE
Revert "rmw_swiftdds: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]"

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7693,7 +7693,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_swiftdds-release.git
-      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/greenstonesoft/rmw_swiftdds.git


### PR DESCRIPTION
This package has been failing to build since it was introduced, and is now blocking RHEL builds in Rolling due to declaration as an RMW provider.

https://build.ros2.org/job/Rbin_uR64__rmw_swiftdds_cpp__ubuntu_resolute_amd64__binary/
https://build.ros2.org/job/Rbin_rhel_el1064__rmw_swiftdds_cpp__rhel_10_x86_64__binary/

This reverts (part of) commit #52698

When the issue is resolved, a new release can be made or this PR can be reverted. Until then, continuing to attempt this build is a waste of project resources.

@greenstonesoft FYI