### PR TITLE
marti_common: 3.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4335,7 +4335,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.9.1-1
+      version: 3.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.11.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.9.1-1`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Adding function to get ellipse points with z-value populated (#807 <https://github.com/swri-robotics/marti_common/issues/807>)
* Contributors: David Anthony
```

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_route_util

```
* Adding obstacle marker to marker array conversion node (#809 <https://github.com/swri-robotics/marti_common/issues/809>)
* Contributors: David Anthony
```

## swri_serial_util

- No changes

## swri_transform_util

```
* Adding warning when moving far away from origin (#810 <https://github.com/swri-robotics/marti_common/issues/810>)
* Fix origin test hang (#808 <https://github.com/swri-robotics/marti_common/issues/808>)
* Add heading support to origin initialization (#806 <https://github.com/swri-robotics/marti_common/issues/806>)
* Fixing multiple issues with how origin was subscribed to and interpreted (#805 <https://github.com/swri-robotics/marti_common/issues/805>)
* Adding copy and copy assignment operator (#804 <https://github.com/swri-robotics/marti_common/issues/804>)
* Contributors: David Anthony
```
