### PR TITLE
swri_console: 2.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10113,7 +10113,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.4.0-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.3.0-1`

## swri_console

```
* Update branch links in README.md to ros2-devel
* Updating README (#90 <https://github.com/swri-robotics/swri_console/issues/90>)
* Fixing trailing comment (#89 <https://github.com/swri-robotics/swri_console/issues/89>)
* Adding ability to dynamically set logger level on Iron and newer  (#88 <https://github.com/swri-robotics/swri_console/issues/88>)
* Contributors: David Anthony
```
