### PR TITLE
Add rqt_multiplot source to distribution.yaml

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9144,6 +9144,12 @@ repositories:
       url: https://github.com/ros-visualization/rqt_msg.git
       version: rolling
     status: maintained
+  rqt_multiplot:
+    source:
+      type: git
+      url: https://github.com/samuelba/rqt_multiplot_plugin.git
+      version: main
+    status: maintained
   rqt_plot:
     doc:
       type: git


### PR DESCRIPTION
This PR adds the rqt_multiplot package to ROS Rolling as a source entry.

This is a source-only addition for initial package naming review prior to creating the corresponding release repository and performing the first Bloom release.

## Package name:

rqt_multiplot

## Package Upstream Source:

https://github.com/samuelba/rqt_multiplot_plugin.git

## Purpose of using this:

An rqt plugin for visualizing numeric values in multiple 2D plots.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/samuelba/rqt_multiplot_plugin.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
